### PR TITLE
refactor: strict mode control to use numbered choice pattern

### DIFF
--- a/.changeset/mytxiw4di6.md
+++ b/.changeset/mytxiw4di6.md
@@ -1,0 +1,13 @@
+---
+"kiro-agents": patch
+---
+
+# Refactor strict mode control to use numbered choice pattern
+
+Replaced userInput tool-based interaction with ADHD-C friendly numbered list format in strict mode control. This change improves compatibility with chit-chat interaction patterns and removes dependency on Kiro-specific tool constraints.
+
+## Changed
+- Strict mode interactive control (`/strict`) now uses numbered choice pattern instead of userInput tool
+- Updated documentation in both `strict.md` and `strict-mode.md` to reflect numbered options interface
+- Replaced "visual buttons" terminology with "numbered choice interface" for consistency
+

--- a/src/core/strict-mode.md
+++ b/src/core/strict-mode.md
@@ -62,13 +62,14 @@ State changed. Response Protocol now applies.
 ### Command 2: Interactive Control
 
 For interactive strict mode control, use the `/strict` slash command (without parameters).
-This provides a visual interface with buttons to:
+This provides a numbered choice interface to:
 - Enable strict mode
 - Disable strict mode
 - Learn more about strict mode
+- Check current state
 
 **Usage:**
-- Interactive: `/strict` (no parameters, loads `strict.md` steering file with userInput buttons)
+- Interactive: `/strict` (no parameters, loads `strict.md` steering file with numbered options)
 - Direct: `/strict on` or `/strict off` (with state)
 
 ## Use Case Guidelines

--- a/src/core/strict.md
+++ b/src/core/strict.md
@@ -1,12 +1,12 @@
 ---
 inclusion: manual
-description: "Interactive strict mode control with visual buttons for enabling/disabling precision mode"
+description: "Interactive strict mode control with numbered options for enabling/disabling precision mode"
 keywords: ["strict", "precision", "mode", "control"]
 ---
 
 # Strict Mode Control
 
-Interactive control for STRICT_MODE using userInput tool.
+Interactive control for STRICT_MODE using numbered choice pattern.
 
 ## Current State Check
 
@@ -14,11 +14,10 @@ First, determine the current STRICT_MODE state from context.
 
 ## Present Interactive Options
 
-Use userInput tool to show interactive buttons:
+Display the question with numbered options:
 
-```typescript
-userInput({
-  question: `# Strict Mode Control
+```markdown
+# Strict Mode Control
 
 **Current State**: STRICT_MODE = ${current_state}
 
@@ -29,30 +28,15 @@ Strict mode blocks execution on ambiguous input and requires explicit clarificat
 - New component creation establishing patterns
 - Debugging propagated errors from incorrect assumptions
 
-**What would you like to do?**`,
-  options: [
-    {
-      title: "🟢 Enable Strict Mode",
-      description: "Activate precision mode - blocks execution on ambiguous input, requires explicit clarification",
-      recommended: current_state === "OFF"
-    },
-    {
-      title: "🔴 Disable Strict Mode",
-      description: "Return to normal mode - allows reasonable assumptions, faster iteration",
-      recommended: current_state === "ON"
-    },
-    {
-      title: "ℹ️ Learn More",
-      description: "Understand when and how to use strict mode effectively"
-    },
-    {
-      title: "📊 Check Current State",
-      description: "Show current strict mode configuration and status"
-    }
-  ],
-  reason: "strict-mode-control"
-})
+**What would you like to do?**
+
+1. **🟢 Enable Strict Mode** - Activate precision mode - blocks execution on ambiguous input, requires explicit clarification
+2. **🔴 Disable Strict Mode** - Return to normal mode - allows reasonable assumptions, faster iteration
+3. **ℹ️ Learn More** - Understand when and how to use strict mode effectively
+4. **📊 Check Current State** - Show current strict mode configuration and status
 ```
+
+**Note**: Recommend option 1 when current_state is "OFF", recommend option 2 when current_state is "ON".
 
 ## Handle User Selection
 


### PR DESCRIPTION
---
"kiro-agents": patch
---

# Refactor strict mode control to use numbered choice pattern

Replaced userInput tool-based interaction with ADHD-C friendly numbered list format in strict mode control. This change improves compatibility with chit-chat interaction patterns and removes dependency on Kiro-specific tool constraints.

## Changed
- Strict mode interactive control (`/strict`) now uses numbered choice pattern instead of userInput tool
- Updated documentation in both `strict.md` and `strict-mode.md` to reflect numbered options interface
- Replaced "visual buttons" terminology with "numbered choice interface" for consistency