### PR TITLE
feat: simplify reflection system to 3-tier hierarchy

### DIFF
--- a/.changeset/ggs0wllg6u.md
+++ b/.changeset/ggs0wllg6u.md
@@ -1,0 +1,18 @@
+---
+"kiro-agents": minor
+---
+
+# Simplify reflection system to 3-tier hierarchy
+
+Streamlined the AI reflection system from 4 tiers to 3 tiers by removing the category tier, and updated file references to remove anchors for better compatibility. This simplification reduces complexity while maintaining full functionality.
+
+## Changed
+- Reflection system now uses 3-tier hierarchy (Universal, Agent, Project) instead of 4-tier
+- File references no longer use anchors (e.g., `#[[file:path.md]]` instead of `#[[file:path.md:insights]]`)
+- All reflection protocols updated to support simplified architecture
+- Documentation updated throughout to reflect 3-tier structure
+
+## Removed
+- Category tier from reflection hierarchy (Universal, ~~Category~~, Agent, Project)
+- File reference anchors for better compatibility with flat file format
+

--- a/docs/INSTALLED-ARCHITECTURE.md
+++ b/docs/INSTALLED-ARCHITECTURE.md
@@ -106,12 +106,10 @@ Both installations work together to provide the complete kiro-agents experience.
     ├── drafts/                             # Pending insights
     │   ├── universal.md
     │   ├── project.md
-    │   ├── categories/
     │   └── agents/
     └── approved/                           # Approved insights
         ├── universal.md
         ├── project.md
-        ├── categories/
         └── agents/
 ```
 
@@ -946,20 +944,12 @@ The reflection system enables agents to capture and reuse knowledge across sessi
     ├── drafts/              # Pending insights awaiting review
     │   ├── universal.md
     │   ├── project.md
-    │   ├── categories/
-    │   │   ├── architects.md
-    │   │   ├── developers.md
-    │   │   └── ...
     │   └── agents/
     │       ├── {agent-name}.md
     │       └── ...
     └── approved/            # Approved insights by tier
         ├── universal.md     # Used by ALL agents
         ├── project.md       # About this project
-        ├── categories/      # Used by agent type
-        │   ├── architects.md
-        │   ├── developers.md
-        │   └── ...
         └── agents/          # Used by specific agent
             ├── {agent-name}.md
             └── ...
@@ -977,15 +967,11 @@ The reflection system enables agents to capture and reuse knowledge across sessi
 - Used by ALL agents
 - Examples: Markdown preferences, approval protocols, team standards
 
-**2. Category Insights** (`.ai-storage/reflections/approved/categories/{category}.md`)
-- Used by agents of specific type (architects, developers, analysts)
-- Examples: Architecture patterns, testing conventions, code style
-
-**3. Agent-Specific Insights** (`.ai-storage/reflections/approved/agents/{agent-name}.md`)
+**2. Agent-Specific Insights** (`.ai-storage/reflections/approved/agents/{agent-name}.md`)
 - Used by one specific agent only
 - Examples: Agent-specific preferences, learned behaviors
 
-**4. Project Insights** (`.ai-storage/reflections/approved/project.md`)
+**3. Project Insights** (`.ai-storage/reflections/approved/project.md`)
 - About this specific project
 - Examples: Project structure, conventions, key files
 
@@ -1064,16 +1050,13 @@ Agents with Reflections section automatically load approved insights:
 ## Reflections
 
 ### Universal Insights
-#[[file:.ai-storage/reflections/approved/universal.md:insights]]
-
-### Category Insights ({agent-category})
-#[[file:.ai-storage/reflections/approved/categories/{agent-category}.md:insights]]
+#[[file:.ai-storage/reflections/approved/universal.md]]
 
 ### Agent-Specific Insights
-#[[file:.ai-storage/reflections/approved/agents/{agent-name}.md:insights]]
+#[[file:.ai-storage/reflections/approved/agents/{agent-name}.md]]
 
 ### Project Insights
-#[[file:.ai-storage/reflections/approved/project.md:insights]]
+#[[file:.ai-storage/reflections/approved/project.md]]
 ```
 
 **File Reference Behavior:**
@@ -1162,7 +1145,6 @@ Category: architect
 
 Reflection files:
 - Universal: .ai-storage/reflections/approved/universal.md
-- Category: .ai-storage/reflections/approved/categories/architect.md
 - Agent: .ai-storage/reflections/approved/agents/kiro-external-product-architect.md
 - Project: .ai-storage/reflections/approved/project.md
 

--- a/docs/design/reflection-architecture.md
+++ b/docs/design/reflection-architecture.md
@@ -35,9 +35,8 @@ Technical design documentation for the AI-managed reflection system in kiro-agen
 - User assigns insights to appropriate tier
 - Approved insights moved to tier-specific files
 
-**3. 4-Tier Hierarchy**
+**3. 3-Tier Hierarchy**
 - Universal (all agents)
-- Category (agent type)
 - Agent-Specific (one agent)
 - Project (project-wide)
 
@@ -60,15 +59,11 @@ Technical design documentation for the AI-managed reflection system in kiro-agen
     ├── drafts/              # Pending insights
     │   ├── universal.md
     │   ├── project.md
-    │   ├── categories/
-    │   │   └── {category}.md
     │   └── agents/
     │       └── {agent-name}.md
     └── approved/            # Approved insights
         ├── universal.md
         ├── project.md
-        ├── categories/
-        │   └── {category}.md
         └── agents/
             └── {agent-name}.md
 ```
@@ -77,22 +72,30 @@ Technical design documentation for the AI-managed reflection system in kiro-agen
 ```markdown
 # {Tier} Reflections
 
-## Insights
-- Insight 1
-- Insight 2
+- **[INSIGHT]** Insight 1 (approved: 2026-01-01)
 
-## Patterns
-- Pattern 1
-- Pattern 2
+- **[INSIGHT]** Insight 2 (approved: 2026-01-02)
 
-## Decisions
-- Decision 1 (rationale: why we chose this)
-- Decision 2
+- **[PATTERN]** Pattern 1 (approved: 2026-01-01)
 
-## Learnings
-- Learning 1 (what we discovered)
-- Learning 2
+- **[PATTERN]** Pattern 2 (approved: 2026-01-03)
+
+- **[DECISION]** Decision 1 (rationale: why we chose this) (approved: 2026-01-02)
+
+- **[DECISION]** Decision 2 (approved: 2026-01-04)
+
+- **[LEARNING]** Learning 1 (what we discovered) (approved: 2026-01-03)
+
+- **[LEARNING]** Learning 2 (approved: 2026-01-05)
 ```
+
+**Format features:**
+- Single header line
+- Each insight is a bullet point with type tag
+- Type tags: `[INSIGHT]`, `[PATTERN]`, `[DECISION]`, `[LEARNING]`
+- Blank line separator between insights
+- Approval date at end
+- No subsections (enables fsAppend for efficient updates)
 
 **Why This Structure:**
 - Separate drafts from approved (clear workflow)
@@ -111,19 +114,15 @@ This agent records insights, patterns, and learnings in its dedicated reflection
 
 ### Universal Insights
 
-#[[file:.ai-storage/reflections/approved/universal.md:insights]]
-
-### Category Insights ({agent-category})
-
-#[[file:.ai-storage/reflections/approved/categories/{agent-category}.md:insights]]
+#[[file:.ai-storage/reflections/approved/universal.md]]
 
 ### Agent-Specific Insights
 
-#[[file:.ai-storage/reflections/approved/agents/{agent-name}.md:insights]]
+#[[file:.ai-storage/reflections/approved/agents/{agent-name}.md]]
 
 ### Project Insights
 
-#[[file:.ai-storage/reflections/approved/project.md:insights]]
+#[[file:.ai-storage/reflections/approved/project.md]]
 ```
 
 **File Reference Behavior:**
@@ -193,7 +192,7 @@ This agent records insights, patterns, and learnings in its dedicated reflection
 ```
 1. Agent discovers insight during work
    ↓
-2. Agent determines tier (Universal, Category, Agent, Project)
+2. Agent determines tier (Universal, Agent, Project)
    ↓
 3. Agent checks if draft file exists
    ├─ If blank/missing → fsWrite (creates file + directories)
@@ -225,7 +224,7 @@ This agent records insights, patterns, and learnings in its dedicated reflection
    ├─ Suggest refinements if needed
    └─ Ask user which tier to approve to
    ↓
-5. User selects tier (Universal, Category, Agent, Project, Reject, Skip)
+5. User selects tier (Universal, Agent, Project, Reject, Skip)
    ↓
 6. Curator moves insight to approved tier
    ├─ Check if approved file exists
@@ -256,7 +255,6 @@ This agent records insights, patterns, and learnings in its dedicated reflection
    ↓
 4. Kiro IDE resolves file references
    ├─ Universal: .ai-storage/reflections/approved/universal.md
-   ├─ Category: .ai-storage/reflections/approved/categories/{category}.md
    ├─ Agent: .ai-storage/reflections/approved/agents/{agent-name}.md
    └─ Project: .ai-storage/reflections/approved/project.md
    ↓
@@ -295,7 +293,7 @@ This agent records insights, patterns, and learnings in its dedicated reflection
 - Scales automatically (new tiers work immediately)
 - Self-documenting (structure emerges from usage)
 
-### Why 4-Tier Hierarchy?
+### Why 3-Tier Hierarchy?
 
 **Alternative Considered:** Flat structure (all insights in one file)
 
@@ -305,13 +303,14 @@ This agent records insights, patterns, and learnings in its dedicated reflection
 - Difficult to maintain (hard to find specific insights)
 - No separation of concerns (personal vs team vs project)
 
-**Chosen Approach:** 4-tier hierarchy (Universal, Category, Agent, Project)
+**Chosen Approach:** 3-tier hierarchy (Universal, Agent, Project)
 
 **Benefits:**
 - Scalable (each tier stays manageable size)
 - Relevant (agents load only applicable insights)
 - Maintainable (easy to find and update insights)
 - Clear separation (personal, team, project scopes)
+- Simple (no complex categorization needed)
 
 ### Why Draft → Approved Workflow?
 
@@ -381,7 +380,6 @@ This agent records insights, patterns, and learnings in its dedicated reflection
 
 **Thresholds:**
 - Universal: ~100 insights (most common)
-- Category: ~50 insights per category
 - Agent: ~30 insights per agent
 - Project: ~50 insights
 
@@ -402,10 +400,9 @@ This agent records insights, patterns, and learnings in its dedicated reflection
 
 **Current Overhead:**
 - Universal: ~500-1000 tokens
-- Category: ~300-500 tokens
 - Agent: ~200-300 tokens
 - Project: ~300-500 tokens
-- **Total: ~1300-2300 tokens** (acceptable)
+- **Total: ~1000-1800 tokens** (acceptable)
 
 ### Team Collaboration
 

--- a/docs/user-guide/reflection-system.md
+++ b/docs/user-guide/reflection-system.md
@@ -63,7 +63,7 @@ To permanently enable reflection on an agent:
 
 ## Insight Tiers
 
-The reflection system organizes insights into 4 tiers based on scope:
+The reflection system organizes insights into 3 tiers based on scope:
 
 ### 1. Universal Insights
 
@@ -78,44 +78,31 @@ The reflection system organizes insights into 4 tiers based on scope:
 
 **When to use:** Insight applies to every agent without exception
 
-### 2. Category Insights
-
-**Used by:** Agents of specific type (architects, developers, analysts, etc.)  
-**Files:** `.ai-storage/reflections/approved/categories/{category}.md`
-
-**Examples:**
-- Architecture patterns (for architect agents)
-- Testing conventions (for developer agents)
-- Analysis techniques (for analyst agents)
-- Code review standards (for reviewer agents)
-
-**When to use:** Insight applies to all agents of a specific type
-
-### 3. Agent-Specific Insights
+### 2. Agent-Specific Insights
 
 **Used by:** One specific agent only  
 **Files:** `.ai-storage/reflections/approved/agents/{agent-name}.md`
 
 **Examples:**
-- Agent-specific workflow preferences
-- Learned behaviors from past sessions
-- Agent-unique capabilities
-- Personal interaction patterns
+- Agent personality preferences
+- Specialized workflows for this agent
+- Agent-specific learned behaviors
+- Custom interaction patterns
 
-**When to use:** Insight only makes sense for one particular agent
+**When to use:** Insight only applies to this specific agent
 
-### 4. Project Insights
+### 3. Project Insights
 
-**Used by:** All agents working on this project  
+**Used by:** ALL agents in this project/workspace  
 **File:** `.ai-storage/reflections/approved/project.md`
 
 **Examples:**
-- "This project uses Bun for package management"
-- "Build system uses centralized manifest in src/manifest.ts"
-- "Authentication is in the auth/ directory"
-- "API endpoints are documented in docs/api.md"
+- Project-specific conventions
+- Codebase patterns and structure
+- Team preferences for this project
+- Project-specific tools and workflows
 
-**When to use:** Insight is about this specific project's structure or conventions
+**When to use:** Insight applies to this project but not others
 
 ## Storage Structure
 
@@ -125,8 +112,14 @@ The reflection system organizes insights into 4 tiers based on scope:
     ├── drafts/              # Pending insights awaiting review
     │   ├── universal.md
     │   ├── project.md
-    │   ├── categories/
-    │   │   └── {category}.md
+    │   └── agents/
+    │       └── {agent-name}.md
+    └── approved/            # Approved insights ready for use
+        ├── universal.md
+        ├── project.md
+        └── agents/
+            └── {agent-name}.md
+```
     │   └── agents/
     │       └── {agent-name}.md
     └── approved/            # Approved insights by tier
@@ -142,7 +135,7 @@ The reflection system organizes insights into 4 tiers based on scope:
 
 ## Insight Types
 
-Each reflection file has 4 subsections for different types of knowledge:
+Each reflection file uses a simple bullet list format with type tags:
 
 ### Insights
 
@@ -150,8 +143,8 @@ General knowledge, preferences, and standards
 
 **Example:**
 ```markdown
-- Markdown: Use 4 backticks for outer blocks, 3 for inner blocks when 
-  showing nested code examples. This prevents premature block closure.
+- **[INSIGHT]** Markdown: Use 4 backticks for outer blocks, 3 for inner blocks when 
+  showing nested code examples. This prevents premature block closure. (approved: 2026-01-01)
 ```
 
 ### Patterns
@@ -160,8 +153,8 @@ Reusable approaches, workflows, and solutions
 
 **Example:**
 ```markdown
-- Workspace Detection: Always check for development files (src/, package.json) 
-  before implementation. External workspaces require proposal-only mode.
+- **[PATTERN]** Workspace Detection: Always check for development files (src/, package.json) 
+  before implementation. External workspaces require proposal-only mode. (approved: 2026-01-01)
 ```
 
 ### Decisions
@@ -170,9 +163,9 @@ Important choices made and their rationale
 
 **Example:**
 ```markdown
-- Protocol Organization: Use 4-tier hierarchy (Universal, Category, Agent, 
+- **[DECISION]** Protocol Organization: Use 4-tier hierarchy (Universal, Category, Agent, 
   Project) instead of flat structure. Rationale: Better scalability and 
-  clearer separation of concerns.
+  clearer separation of concerns. (approved: 2026-01-02)
 ```
 
 ### Learnings
@@ -181,8 +174,8 @@ Lessons from successes or failures
 
 **Example:**
 ```markdown
-- Build Validation: `bun run dev` with 5-second timeout is sufficient for 
-  validation. Full test suite not needed for quick iteration cycles.
+- **[LEARNING]** Build Validation: `bun run dev` with 5-second timeout is sufficient for 
+  validation. Full test suite not needed for quick iteration cycles. (approved: 2026-01-02)
 ```
 
 ## Workflow Details

--- a/src/core/protocols/reflect-agent-insights.md
+++ b/src/core/protocols/reflect-agent-insights.md
@@ -23,18 +23,24 @@ This protocol guides agents on how to capture insights, patterns, decisions, and
 **Where should this insight be recorded?**
 
 - **Universal** (`.ai-storage/reflections/drafts/universal.md`) - Useful for ALL agents
-  - Examples: Markdown preferences, approval protocols, team standards
-  
-- **Category** (`.ai-storage/reflections/drafts/categories/{category}.md`) - Useful for agent type
-  - Examples: Architecture patterns (architects), testing conventions (developers)
+  - Examples: Markdown preferences, approval protocols, error handling patterns, documentation standards
   
 - **Agent-Specific** (`.ai-storage/reflections/drafts/agents/{agent-name}.md`) - Only this agent
-  - Examples: Agent-specific preferences, learned behaviors
+  - Examples: Agent-specific workflows, learned behaviors, specialized techniques
   
 - **Project** (`.ai-storage/reflections/drafts/project.md`) - About this project
-  - Examples: Project structure, conventions, key files
+  - Examples: Project structure, user preferences, conventions, key files, team standards
 
-### Step 2: Check if Draft File Exists
+### Step 2: Determine Insight Type Tag
+
+**Choose the appropriate type tag:**
+
+- `[INSIGHT]` - General knowledge, preferences, standards
+- `[PATTERN]` - Reusable approaches, workflows, solutions
+- `[DECISION]` - Important choices made and their rationale
+- `[LEARNING]` - Lessons from successes or failures
+
+### Step 3: Check if Draft File Exists
 
 **Try to read the target draft file:**
 
@@ -43,53 +49,51 @@ Read: .ai-storage/reflections/drafts/{tier}/{file}.md
 ```
 
 **If file doesn't exist or is empty:**
-- Go to Step 3 (Create)
+- Go to Step 4 (Create)
 
 **If file exists with content:**
-- Go to Step 4 (Append)
+- Go to Step 5 (Append)
 
-### Step 3: Create Draft File (First Time)
+### Step 4: Create Draft File (First Time)
 
-Use `fsWrite` to create the draft file with all subsections:
+Use `fsWrite` to create the draft file with header and first insight:
 
 ```markdown
 # {Tier} Draft Reflections
 
-## Insights (Draft)
-
-{Your insight if type is Insights}
-
-## Patterns (Draft)
-
-{Your insight if type is Patterns}
-
-## Decisions (Draft)
-
-{Your insight if type is Decisions}
-
-## Learnings (Draft)
-
-{Your insight if type is Learnings}
+- **[TYPE]** {Your insight content} (captured: {YYYY-MM-DD})
 ```
+
+**Replace:**
+- `{Tier}` - Universal, Category Name, Agent Name, or Project
+- `[TYPE]` - INSIGHT, PATTERN, DECISION, or LEARNING
+- `{Your insight content}` - The actual insight text
+- `{YYYY-MM-DD}` - Current date (e.g., 2026-01-01)
 
 **Note:** fsWrite automatically creates all missing directories (`.ai-storage/reflections/drafts/`).
 
 **Important:** Agents ALWAYS write to drafts first, never directly to approved files. Only the reflection-curator agent moves insights from drafts to approved after review.
 
-**Then:** Skip to Step 5 (Done)
+**Then:** Skip to Step 6 (Done)
 
-### Step 4: Append to Existing Draft File
+### Step 5: Append to Existing Draft File
 
-Use `fsAppend` to add to the appropriate subsection:
+Use `fsAppend` to add the new insight:
 
 ```markdown
 
-- {Your insight content} (captured: {date})
+- **[TYPE]** {Your insight content} (captured: {YYYY-MM-DD})
 ```
 
-**Important:** Add to the correct subsection (Insights, Patterns, Decisions, or Learnings).
+**Format rules:**
+- Start with blank line (separator)
+- Use `- **[TYPE]**` prefix (TYPE in uppercase)
+- Include capture date in parentheses
+- Keep insight on single line if possible (use line breaks only if necessary)
 
-### Step 5: Notify User (Optional)
+**Important:** This format allows `fsAppend` to work without reading the file first.
+
+### Step 6: Notify User (Optional)
 
 Briefly mention the insight was captured:
 
@@ -118,26 +122,50 @@ Briefly mention the insight was captured:
 ### Good Insight (Universal)
 
 ```markdown
-- Markdown: Use 4 backticks for outer blocks, 3 for inner blocks when showing nested code examples. This prevents premature block closure in the parser.
+- **[INSIGHT]** Markdown: Use 4 backticks for outer blocks, 3 for inner blocks when showing nested code examples. This prevents premature block closure in the parser. (captured: 2026-01-01)
 ```
 
-### Good Pattern (Category: Architects)
+### Good Pattern (Agent-Specific)
 
 ```markdown
-- Workspace Detection Pattern: Always check for development files (src/manifest.ts, package.json, scripts/) before implementation. External workspaces require proposal-only mode.
+- **[PATTERN]** Workspace Detection: Always check for development files (src/manifest.ts, package.json, scripts/) before implementation. External workspaces require proposal-only mode. (captured: 2026-01-01)
 ```
 
 ### Good Decision (Agent-Specific)
 
 ```markdown
-- Protocol Organization: Decided to use 4-tier hierarchy (Universal, Category, Agent, Project) instead of flat structure. Rationale: Better scalability and clearer separation of concerns.
+- **[DECISION]** Protocol Organization: Decided to use 4-tier hierarchy (Universal, Category, Agent, Project) instead of flat structure. Rationale: Better scalability and clearer separation of concerns. (captured: 2026-01-01)
 ```
 
 ### Good Learning (Project)
 
 ```markdown
-- Build System: Learned that `bun run dev` with 5-second timeout is sufficient for validation. Full test suite not needed for quick iteration cycles.
+- **[LEARNING]** Build System: Learned that `bun run dev` with 5-second timeout is sufficient for validation. Full test suite not needed for quick iteration cycles. (captured: 2026-01-01)
 ```
+
+## File Format Example
+
+**Complete draft file structure:**
+
+```markdown
+# Universal Draft Reflections
+
+- **[INSIGHT]** Use 4 backticks for outer blocks, 3 for inner. Prevents premature block closure. (captured: 2026-01-01)
+
+- **[PATTERN]** Workspace Detection: Check for src/manifest.ts before implementation. External workspaces require proposal-only mode. (captured: 2026-01-01)
+
+- **[DECISION]** Protocol Organization: 4-tier hierarchy instead of flat. Rationale: Better scalability. (captured: 2026-01-02)
+
+- **[LEARNING]** Build System: `bun run dev` with 5s timeout sufficient for validation. (captured: 2026-01-02)
+```
+
+**Key features:**
+- Single header line
+- Each insight is a separate bullet point
+- Type tag in bold brackets
+- Blank line separator between insights
+- Capture date at end
+- No subsections (enables fsAppend)
 
 ## Integration with Agent Definition
 
@@ -147,16 +175,13 @@ Agents with Reflections section in their definition will have file references th
 ## Reflections
 
 ### Universal Insights
-#[[file:.ai-storage/reflections/approved/universal.md:insights]]
-
-### Category Insights
-#[[file:.ai-storage/reflections/approved/categories/{category}.md:insights]]
+#[[file:.ai-storage/reflections/approved/universal.md]]
 
 ### Agent-Specific Insights
-#[[file:.ai-storage/reflections/approved/agents/{agent-name}.md:insights]]
+#[[file:.ai-storage/reflections/approved/agents/{agent-name}.md]]
 
 ### Project Insights
-#[[file:.ai-storage/reflections/approved/project.md:insights]]
+#[[file:.ai-storage/reflections/approved/project.md]]
 ```
 
 **Note:** Agents write insights to drafts (`.ai-storage/reflections/drafts/`). The reflection-curator agent reviews drafts and moves approved insights to the appropriate approved tier (`.ai-storage/reflections/approved/`).

--- a/src/core/protocols/reflect-curator-checklist.md
+++ b/src/core/protocols/reflect-curator-checklist.md
@@ -262,48 +262,40 @@ Check package.json version before publishing. Use semantic versioning: major.min
 **Criteria:**
 - Applies to ALL agents
 - No exceptions or special cases
-- Fundamental to system operation
+- Fundamental to system operation or widely applicable best practices
 
 **Examples:**
 - Markdown formatting rules
 - File operation patterns
 - Approval protocols
-- Team-wide standards
-
-### Category Tier
-
-**Criteria:**
-- Applies to specific agent type
-- Shared by multiple agents of same category
-- Category-specific best practices
-
-**Examples:**
-- Architecture patterns (for architect agents)
-- Testing conventions (for developer agents)
-- Analysis techniques (for analyst agents)
+- Error handling conventions
+- Documentation standards
 
 ### Agent-Specific Tier
 
 **Criteria:**
 - Applies to ONE agent only
-- Agent-specific preferences or behaviors
-- Unique to agent's role
+- Agent-specific workflows or behaviors
+- Unique to agent's specialized role
 
 **Examples:**
 - Agent-specific workflow preferences
 - Learned behaviors from past sessions
 - Agent-unique capabilities
+- Specialized techniques for specific tasks
 
 ### Project Tier
 
 **Criteria:**
 - About THIS project specifically
 - Project structure or conventions
+- User preferences for this workspace
 - Key files or patterns in this codebase
 
 **Examples:**
 - "This project uses Bun for package management"
 - "Build system uses centralized manifest in src/manifest.ts"
+- "User prefers integration tests over unit tests"
 - "Protocols are auto-discovered via glob patterns"
 
 ## Edge Cases

--- a/src/core/protocols/reflect-manager-workflow.md
+++ b/src/core/protocols/reflect-manager-workflow.md
@@ -26,21 +26,20 @@ This protocol enables batch enablement of reflection system across multiple agen
 **For each agent file:**
 1. Read agent definition
 2. Check if Reflections section exists
-3. Determine agent category (from frontmatter or content)
-4. Build agent list with status
+3. Build agent list with status
 
 **Display:**
 
 ```diff
 📋 AGENT REFLECTION STATUS
 
-# | Agent Name                    | Category    | Reflections
---|-------------------------------|-------------|------------
-1 | kiro-master                   | management  | ✅ Enabled
-2 | kiro-external-product-architect| architect   | ❌ Disabled
-3 | reflection-curator            | curator     | ✅ Enabled
-4 | custom-agent-1                | developer   | ❌ Disabled
-5 | custom-agent-2                | analyst     | ❌ Disabled
+# | Agent Name                    | Reflections
+--|-------------------------------|------------
+1 | kiro-master                   | ✅ Enabled
+2 | kiro-external-product-architect| ❌ Disabled
+3 | reflection-curator            | ✅ Enabled
+4 | custom-agent-1                | ❌ Disabled
+5 | custom-agent-2                | ❌ Disabled
 ...
 
 Total: {count} agents
@@ -57,10 +56,9 @@ Which agents should have reflection enabled?
 
 Options:
 1. **All disabled agents** - Enable all agents without Reflections
-2. **By category** - Enable all agents of specific type
-3. **By range** - Enable agents by number (e.g., "2-5, 10, 15-16")
-4. **By list** - Enable specific agents (e.g., "1, 4, 10")
-5. **Cancel** - Exit without changes
+2. **By range** - Enable agents by number (e.g., "2-5, 10, 15-16")
+3. **By list** - Enable specific agents (e.g., "1, 4, 10")
+4. **Cancel** - Exit without changes
 
 Enter your choice:
 ```
@@ -71,23 +69,18 @@ Enter your choice:
 - Select all agents with ❌ Disabled status
 - Proceed to Step 4
 
-**Option 2 (By category):**
-- Ask: "Which category? (architect, developer, analyst, etc.)"
-- Select all agents matching category
-- Proceed to Step 4
-
-**Option 3 (By range):**
+**Option 2 (By range):**
 - Parse range syntax: "2-5, 10, 15-16"
 - Expand ranges: 2, 3, 4, 5, 10, 15, 16
 - Select agents by numbers
 - Proceed to Step 4
 
-**Option 4 (By list):**
+**Option 3 (By list):**
 - Parse list syntax: "1, 4, 10"
 - Select agents by numbers
 - Proceed to Step 4
 
-**Option 5 (Cancel):**
+**Option 4 (Cancel):**
 - Exit workflow
 - No changes made
 
@@ -126,14 +119,7 @@ Read: {{{WS_AGENTS_PATH}}}/{agent-name}.md
 **If Reflections section doesn't exist:**
 - Proceed to 5c
 
-#### 5c. Determine Agent Category
-
-**Extract category from:**
-- Frontmatter: `type: {category}`
-- Content: Look for category mentions
-- Default: "general" if not found
-
-#### 5d. Add Reflections Section
+#### 5c. Add Reflections Section
 
 **For Permanent enablement:**
 
@@ -147,26 +133,22 @@ This agent records insights, patterns, and learnings in its dedicated reflection
 
 ### Universal Insights
 
-#[[file:.ai-storage/reflections/approved/universal.md:insights]]
-
-### Category Insights ({category})
-
-#[[file:.ai-storage/reflections/approved/categories/{category}.md:insights]]
+#[[file:.ai-storage/reflections/approved/universal.md]]
 
 ### Agent-Specific Insights
 
-#[[file:.ai-storage/reflections/approved/agents/{agent-name}.md:insights]]
+#[[file:.ai-storage/reflections/approved/agents/{agent-name}.md]]
 
 ### Project Insights
 
-#[[file:.ai-storage/reflections/approved/project.md:insights]]
+#[[file:.ai-storage/reflections/approved/project.md]]
 ````
 
 **For Temporary enablement:**
 - Add to session context only (not to file)
 - Log: "Reflections enabled temporarily for {agent-name}"
 
-#### 5e. Log Result
+#### 5d. Log Result
 
 ```
 ✅ Enabled reflection for: {agent-name} ({enablement-type})
@@ -237,29 +219,12 @@ Result: Agents #1, #2, #3, #7, #10, #11, #12
 
 ## Category Detection
 
-### From Frontmatter
+**Note:** Category tier has been removed. Reflection system now uses 3 tiers:
+- Universal (all agents)
+- Agent-Specific (one agent)
+- Project (this project)
 
-```yaml
----
-name: my-agent
-type: architect
----
-```
-
-Extract: `architect`
-
-### From Content
-
-Look for patterns:
-- "Category: {category}"
-- "Type: {category}"
-- "Role: {category}"
-
-Extract first match.
-
-### Default
-
-If no category found: `general`
+This section is deprecated and kept for reference only.
 
 ## Enablement Types
 

--- a/src/core/reflect.md
+++ b/src/core/reflect.md
@@ -42,22 +42,18 @@ This agent records insights, patterns, and learnings in its dedicated reflection
 
 ### Universal Insights
 
-#[[file:.ai-storage/reflections/approved/universal.md:insights]]
-
-### Category Insights ({agent-category})
-
-#[[file:.ai-storage/reflections/approved/categories/{agent-category}.md:insights]]
+#[[file:.ai-storage/reflections/approved/universal.md]]
 
 ### Agent-Specific Insights
 
-#[[file:.ai-storage/reflections/approved/agents/{agent-name}.md:insights]]
+#[[file:.ai-storage/reflections/approved/agents/{agent-name}.md]]
 
 ### Project Insights
 
-#[[file:.ai-storage/reflections/approved/project.md:insights]]
+#[[file:.ai-storage/reflections/approved/project.md]]
 ````
 
-**Important:** Replace `{agent-category}` and `{agent-name}` with actual values from agent definition frontmatter.
+**Important:** Replace `{agent-name}` with actual value from agent definition frontmatter.
 
 **Step 3: Load capture protocol**
 
@@ -75,14 +71,12 @@ This protocol is loaded **only for this session**. Next session without `/reflec
 ✅ REFLECTION ENABLED FOR THIS SESSION
 
 Agent: {agent-name}
-Category: {agent-category}
 
 Reflections section: Added to agent file (permanent)
 Capture protocol: Loaded in context (this session only)
 
 Reflection files:
 - Universal: .ai-storage/reflections/approved/universal.md
-- Category: .ai-storage/reflections/approved/categories/{agent-category}.md
 - Agent: .ai-storage/reflections/approved/agents/{agent-name}.md
 - Project: .ai-storage/reflections/approved/project.md
 
@@ -146,7 +140,6 @@ Enable agents to capture and reuse knowledge across sessions:
 ### Insight Tiers
 
 **Universal** - Used by ALL agents  
-**Category** - Used by agent type (architects, developers, etc.)  
 **Agent-Specific** - Used by one agent only  
 **Project** - About this specific project
 


### PR DESCRIPTION
---
"kiro-agents": minor
---

# Simplify reflection system to 3-tier hierarchy

Streamlined the AI reflection system from 4 tiers to 3 tiers by removing the category tier, and updated file references to remove anchors for better compatibility. This simplification reduces complexity while maintaining full functionality.

## Changed
- Reflection system now uses 3-tier hierarchy (Universal, Agent, Project) instead of 4-tier
- File references no longer use anchors (e.g., `#[[file:path.md]]` instead of `#[[file:path.md:insights]]`)
- All reflection protocols updated to support simplified architecture
- Documentation updated throughout to reflect 3-tier structure

## Removed
- Category tier from reflection hierarchy (Universal, ~~Category~~, Agent, Project)
- File reference anchors for better compatibility with flat file format