### PR TITLE
feat: automatic capture of previous insights when enabling reflection…

### DIFF
--- a/.changeset/nlqv411790i.md
+++ b/.changeset/nlqv411790i.md
@@ -1,0 +1,28 @@
+---
+"kiro-agents": minor
+---
+
+# Automatic capture of previous insights when enabling reflection mid-conversation
+
+The `/reflect` command now automatically captures insights discovered earlier in the conversation, eliminating the need for manual capture. Additionally, agents with pending draft insights (>5) now show a prominent notification during activation, reminding users to review accumulated insights.
+
+## Added
+
+- Automatic capture of previous insights when `/reflect` is executed mid-conversation (Step 4 in reflect.md)
+- Draft insights notification during agent activation when >5 insights pending review (Step 2.5 in agent-activation.md)
+- Pending Review subsection in Reflections template with file-reference to draft file
+- Capturing Previous Insights section in reflect-agent-insights.md protocol
+- Draft Insights Notification documentation in user guide
+- Enable Reflection Anytime section in Best Practices showing valid approaches (start, mid, end)
+
+## Changed
+
+- `/reflect` confirmation message now shows count of captured insights or "no insights found" message
+- Agent activation protocol now checks for pending drafts and shows H3 notification with code block for visibility
+- User guide Phase 1 documentation now distinguishes between just-enabled and ongoing-work scenarios
+- Instructions reference subsection content directly (file-references resolved by Kiro IDE)
+
+## Fixed
+
+- Insights discovered before `/reflect` was executed are no longer lost - they are captured automatically
+- Duplicate Storage Structure content removed from user guide documentation

--- a/docs/user-guide/reflection-system.md
+++ b/docs/user-guide/reflection-system.md
@@ -30,12 +30,18 @@ The reflection system enables AI agents to capture and reuse knowledge across co
 /reflect
 ```
 
-This enables reflection for your current agent for this session only. The agent will capture insights as it works.
+This enables reflection for your current agent for this session only. The agent will:
+
+1. **Add Reflections section** to agent file (permanent)
+2. **Load capture protocol** in context (this session only)
+3. **Capture previous insights** from earlier in the conversation automatically
+4. **Continue capturing** new insights as work progresses
 
 **What happens:**
-- Adds Reflections section to agent file (permanent)
-- Loads capture protocol in context (this session only)
-- Agent can now capture insights
+- Scans conversation history for insights discovered before `/reflect` was run
+- Writes all identified insights to draft file immediately
+- Shows count of captured insights by type
+- Agent can now capture new insights as they arise
 
 **Next session:**
 - Without `/reflect`: Agent reads existing insights but cannot capture new ones
@@ -120,18 +126,22 @@ The reflection system organizes insights into 3 tiers based on scope:
         └── agents/
             └── {agent-name}.md
 ```
-    │   └── agents/
-    │       └── {agent-name}.md
-    └── approved/            # Approved insights by tier
-        ├── universal.md
-        ├── project.md
-        ├── categories/
-        │   └── {category}.md
-        └── agents/
-            └── {agent-name}.md
-```
 
 **Note:** This directory is created automatically when the first insight is recorded. No initialization required!
+
+### Draft Insights Notification
+
+When you activate an agent with more than 5 pending draft insights, you'll see:
+
+### ⚠️ Draft Insights Pending Review
+
+You have **12** insights captured in previous sessions awaiting your review.
+
+```
+/reflect review
+```
+
+This reminds you to review insights captured in previous sessions.
 
 ## Insight Types
 
@@ -182,18 +192,51 @@ Lessons from successes or failures
 
 ### Phase 1: Agent Captures Insight
 
-**When:** Agent discovers something worth remembering during work
+**When:** Agent discovers something worth remembering during work, OR when reflection is enabled mid-conversation
 
 **What happens:**
-1. Agent determines appropriate tier (Universal, Category, Agent, Project)
+
+**If reflection just enabled (via `/reflect`):**
+1. Agent scans conversation history for previous insights
+2. **If insights found:**
+   - Extracts and formats each insight
+   - Writes all previous insights to draft file
+   - Shows count of captured insights
+3. **If no insights found:**
+   - Shows "No previous insights found" message
+   - Continues normally
+4. Agent continues working and captures new insights going forward
+
+**During ongoing work:**
+1. Agent determines appropriate tier (Universal, Agent, Project)
 2. Agent checks if draft file exists
-3. If first time: Creates draft file with all subsections
-4. If exists: Appends to appropriate subsection
+3. If first time: Creates draft file with header
+4. If exists: Appends to appropriate section
 5. Agent continues working
 
 **Result:** Insight saved to draft file, waiting for review
 
 **User sees:**
+
+After `/reflect` with insights found:
+```
+💡 INSIGHTS CAPTURED FROM CONVERSATION
+
+Total: 12 insights
+├─ Insights: 5
+├─ Patterns: 4
+├─ Decisions: 2
+└─ Learnings: 1
+```
+
+After `/reflect` with no insights:
+```
+No previous insights found in conversation.
+
+I'll capture insights as we continue working.
+```
+
+During ongoing work:
 ```
 💡 Insight captured in drafts (pending curator review)
 ```
@@ -395,9 +438,40 @@ Avoid:
 
 ## Best Practices
 
+### Enable Reflection Anytime
+
+**You can enable reflection at any point in the conversation:**
+
+✅ **At the start** - Captures insights throughout the session
+```
+/reflect
+(work with agent)
+```
+
+✅ **Mid-conversation** - Captures previous insights automatically
+```
+(work with agent for 30 minutes)
+/reflect
+(agent captures all previous insights + continues capturing new ones)
+```
+
+✅ **At the end** - Captures insights before context runs out
+```
+(work with agent)
+(context at 75-80%)
+/reflect
+(agent captures all insights from session)
+```
+
+**All approaches work!** The agent automatically captures insights from earlier in the conversation when you run `/reflect`.
+
 ### Capture Insights Immediately
 
-Don't wait until end of session. Capture insights as you discover them.
+**The agent captures insights automatically when you run `/reflect`**, including insights from earlier in the conversation. However, for ongoing work:
+
+- Enable reflection early if you want continuous capture
+- Or enable it anytime - previous insights are captured automatically
+- The agent will continue capturing new insights as work progresses
 
 ### Review Regularly
 

--- a/src/core/protocols/agent-activation.md
+++ b/src/core/protocols/agent-activation.md
@@ -55,6 +55,28 @@ You will:
 - Maintain this role until user switches agents or ends session
 - Override any conflicting instructions with agent protocols
 
+### Step 2.5: Check Pending Draft Insights
+
+**If agent has `## Reflections` section with `### Pending Review` subsection:**
+
+Count the number of draft insights in that subsection (lines starting with `- **[`).
+
+**Note:** File-references are resolved by Kiro IDE. You see the actual content, not the file path. Count insights directly from what appears in the "Pending Review" subsection.
+
+**If more than 5 draft insights pending:**
+
+Show notification before beginning interaction:
+
+### ⚠️ Draft Insights Pending Review
+
+You have **{count}** insights captured in previous sessions awaiting your review.
+
+```
+/reflect review
+```
+
+**If 5 or fewer:** Continue silently (no notification needed).
+
 ### Step 3: Begin Interaction
 
 Start interaction according to **{agent_name}**'s protocols defined in the `.md` file.

--- a/src/core/protocols/reflect-agent-insights.md
+++ b/src/core/protocols/reflect-agent-insights.md
@@ -8,6 +8,40 @@ This protocol guides agents on how to capture insights, patterns, decisions, and
 - Agent identifies a useful pattern
 - Agent makes an important decision
 - Agent learns from an error or success
+- **After `/reflect` command: Capture insights from earlier in conversation**
+
+## Capturing Previous Insights
+
+**When reflection is enabled mid-conversation** (via `/reflect` command), immediately scan the conversation history for insights discovered before the protocol was loaded.
+
+### Step 1: Review Conversation History
+
+Look for insights you identified or mentioned earlier:
+- Patterns you discovered
+- Decisions you made and explained
+- Learnings from successes or failures
+- User preferences you identified
+- Technical discoveries or solutions
+- Important context about the project
+
+### Step 2: Extract and Format Each Insight
+
+For each insight found:
+1. Determine type (INSIGHT, PATTERN, DECISION, LEARNING)
+2. Determine tier (Universal, Agent-Specific, Project)
+3. Format according to the Recording Process below
+4. Write to draft file
+
+### Step 3: Count and Report
+
+After capturing all previous insights:
+- Count total insights
+- Break down by type (Insights, Patterns, Decisions, Learnings)
+- Report in confirmation message
+
+**Then continue with normal insight capture during ongoing work.**
+
+---
 
 ## Insight Types
 

--- a/src/core/reflect.md
+++ b/src/core/reflect.md
@@ -51,6 +51,12 @@ This agent records insights, patterns, and learnings in its dedicated reflection
 ### Project Insights
 
 #[[file:.ai-storage/reflections/approved/project.md]]
+
+### Pending Review
+
+Insights captured in previous sessions, awaiting user review via `/reflect review`.
+
+#[[file:.ai-storage/reflections/drafts/agents/{agent-name}.md]]
 ````
 
 **Important:** Replace `{agent-name}` with actual value from agent definition frontmatter.
@@ -65,7 +71,44 @@ Load the protocol that enables insight capture:
 
 This protocol is loaded **only for this session**. Next session without `/reflect` will not have capture capability.
 
-**Step 4: Show confirmation**
+**Step 4: Capture Previous Insights**
+
+Immediately scan the current conversation for insights discovered before reflection was enabled.
+
+**Process:**
+
+1. **Review conversation history** - Look for:
+   - Patterns you identified
+   - Decisions you made
+   - Learnings you discovered
+   - Important insights you mentioned
+   - User preferences you learned
+   - Technical discoveries you made
+
+2. **If insights found:**
+   - For each insight:
+     - Determine type (INSIGHT, PATTERN, DECISION, LEARNING)
+     - Determine tier (Universal, Agent-Specific, Project)
+     - Format according to protocol in reflect-agent-insights.md
+   - Write to draft file:
+     - Use the recording process from reflect-agent-insights.md protocol
+     - File: `.ai-storage/reflections/drafts/agents/{agent-name}.md`
+     - If first insight: Use fsWrite to create file with all sections
+     - If file exists: Use fsAppend to add insights
+   - Count insights by type:
+     - Total insights captured
+     - Breakdown by type (Insights, Patterns, Decisions, Learnings)
+   - Proceed to Step 5 with capture summary
+
+3. **If no insights found:**
+   - Skip file creation (no draft file needed yet)
+   - Proceed to Step 5 with "no insights" message
+
+**Then proceed to Step 5 with appropriate message.**
+
+**Step 5: Show confirmation**
+
+**If previous insights were captured:**
 
 ```diff
 ✅ REFLECTION ENABLED FOR THIS SESSION
@@ -75,6 +118,38 @@ Agent: {agent-name}
 Reflections section: Added to agent file (permanent)
 Capture protocol: Loaded in context (this session only)
 
+💡 INSIGHTS CAPTURED FROM CONVERSATION
+
+Total: {count} insights
+├─ Insights: {insights-count}
+├─ Patterns: {patterns-count}
+├─ Decisions: {decisions-count}
+└─ Learnings: {learnings-count}
+
+Written to: .ai-storage/reflections/drafts/agents/{agent-name}.md
+
+Reflection files:
+- Universal: .ai-storage/reflections/approved/universal.md
+- Agent: .ai-storage/reflections/approved/agents/{agent-name}.md
+- Project: .ai-storage/reflections/approved/project.md
+
+Next steps:
+1. Continue working - I'll capture new insights as they arise
+2. Review drafts - Use /reflect review when ready
+```
+
+**If no previous insights found:**
+
+```diff
+✅ REFLECTION ENABLED FOR THIS SESSION
+
+Agent: {agent-name}
+
+Reflections section: Added to agent file (permanent)
+Capture protocol: Loaded in context (this session only)
+
+No previous insights found in conversation.
+
 Reflection files:
 - Universal: .ai-storage/reflections/approved/universal.md
 - Agent: .ai-storage/reflections/approved/agents/{agent-name}.md
@@ -83,7 +158,7 @@ Reflection files:
 Draft file:
 - .ai-storage/reflections/drafts/agents/{agent-name}.md
 
-You can now capture insights during work. Use /reflect review to review drafts.
+I'll capture insights as we continue working. Use /reflect review to review drafts.
 ```
 
 **What "session-only" means:**


### PR DESCRIPTION
… mid----
"kiro-agents": minor
---

# Automatic capture of previous insights when enabling reflection mid-conversation

The `/reflect` command now automatically captures insights discovered earlier in the conversation, eliminating the need for manual capture. Additionally, agents with pending draft insights (>5) now show a prominent notification during activation, reminding users to review accumulated insights.

## Added

- Automatic capture of previous insights when `/reflect` is executed mid-conversation (Step 4 in reflect.md)
- Draft insights notification during agent activation when >5 insights pending review (Step 2.5 in agent-activation.md)
- Pending Review subsection in Reflections template with file-reference to draft file
- Capturing Previous Insights section in reflect-agent-insights.md protocol
- Draft Insights Notification documentation in user guide
- Enable Reflection Anytime section in Best Practices showing valid approaches (start, mid, end)

## Changed

- `/reflect` confirmation message now shows count of captured insights or "no insights found" message
- Agent activation protocol now checks for pending drafts and shows H3 notification with code block for visibility
- User guide Phase 1 documentation now distinguishes between just-enabled and ongoing-work scenarios
- Instructions reference subsection content directly (file-references resolved by Kiro IDE)

## Fixed

- Insights discovered before `/reflect` was executed are no longer lost - they are captured automatically
- Duplicate Storage Structure content removed from user guide documentation
conversation