### PR TITLE
fix: migrate agent definitions directory to avoid conflict with kiro …

### DIFF
--- a/.changeset/3qqfctswk34.md
+++ b/.changeset/3qqfctswk34.md
@@ -1,0 +1,18 @@
+---
+"kiro-agents": major
+---
+
+# Migrate agent definitions directory to avoid conflict with Kiro Subagents
+
+Kiro IDE's official Subagents feature uses the same directory as kiro-agents for custom agent definitions, causing Kiro models to fail when listing or reading Subagents due to incompatible file formats. The agent storage path has been updated across the build system, protocols, and all documentation to resolve this conflict. **Existing users must manually move their agent files from `.kiro/agents/` to `.kiro/kiro-agents/`.**
+
+## Added
+- New `{{{GLOBAL_AGENTS_PATH}}}` substitution key in `src/config.ts` and `src/kiro/config.ts` for global user-level agent path
+
+## Changed
+- `src/kiro/config.ts`: updated `{{{WS_AGENTS_PATH}}}` substitution and `getAgentList()` to use new agent directory
+- `src/core/protocols/strict-mode.md`: replaced hardcoded agent path with `{{{WS_AGENTS_PATH}}}` substitution
+- Documentation updated across `README.md`, `CONTRIBUTING.md`, `docs/ARCHITECTURE.md`, `docs/GETTING_STARTED.md`, `docs/INSTALLED-ARCHITECTURE.md`, `docs/design/reflection-architecture.md`, `docs/user-guide/reflection-system.md`
+
+## Fixed
+- Conflict with Kiro IDE's official Subagents feature that caused model failures when scanning for custom subagents

--- a/.changeset/y0cg5evfsq.md
+++ b/.changeset/y0cg5evfsq.md
@@ -1,0 +1,21 @@
+---
+"kiro-agents": major
+---
+
+# Fix kiro-protocols power installation to be compatible with current Kiro IDE versions
+
+The previous CLI installer used symlinks and wrote to `registry.json`, which Kiro IDE no longer uses to determine installed custom powers. The installer now replicates exactly what Kiro IDE does when a user installs a power via "Add Custom Power" UI: physical file copy and registration in the correct manifest files. **Existing installations are broken and require running `npx kiro-agents` again to reinstall.**
+
+## Changed
+- `bin/cli.template.ts`: rewritten power installation — physical file copy replaces symlinks, correct Kiro IDE registry files are now written
+- `docs/contributing/DUAL_INSTALLATION.md`: updated to document new two-directory power installation architecture and correct registry file locations
+- `docs/INSTALLED-ARCHITECTURE.md`: updated directory structure, registry integration, and file permissions sections
+- `docs/contributing/TESTING.md`: updated verification commands to reflect new registry files
+
+## Fixed
+- `bin/cli.template.ts`: power no longer silently fails to appear in Kiro Powers UI after running `npx kiro-agents`
+- `bin/cli.template.ts`: EPERM error on Windows caused by read-only source files during Kiro IDE's internal copy operation
+
+## Removed
+- `bin/cli.template.ts`: symlink-based installation removed — `createSymbolicLinks()` function deleted
+- `bin/cli.template.ts`: `registry.json` registration removed — `registerPowerInRegistry()` function deleted

--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,10 @@ __*
 
 # workspace agents
 .kiro/agents/
+.kiro/kiro-agents/
+
+# workspace settings
+.kiro/settings/mcp.json
 
 # Changeset snapshots (temporary session data)
 .kiro/session-snapshots/

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -44,7 +44,7 @@ When working on this codebase, follow these principles:
 **Purpose**: Specialized AI agents with defined capabilities and workflows
 
 **Implementation**:
-- Agents defined in `.kiro/agents/{name}.md` files
+- Agents defined in `.kiro/kiro-agents/{name}.md` files
 - Activated via `/agents {name}` command (instruction alias pattern)
 - Interactive management via `/agents` command
 - Each agent loads its definition and assumes that role completely
@@ -100,7 +100,7 @@ When working on this codebase, follow these principles:
 **Implementation**:
 - Defined in `src/core/reflect.md` (steering document with commands)
 - Protocols in `src/core/protocols/reflect-*.md` (4 protocols)
-- Curator agent in `.kiro/agents/reflection-curator.md`
+- Curator agent in `.kiro/kiro-agents/reflection-curator.md`
 - Storage in `.ai-storage/reflections/` (on-demand creation)
 
 **Key Behaviors**:
@@ -149,15 +149,15 @@ npx kiro-agents  # or bunx kiro-agents
 - **kiro-protocols power** → `~/.kiro/powers/kiro-protocols/`
   - Power metadata (POWER.md, mcp.json, icon.png)
   - Protocol files in steering/ subdirectory
-  - Symbolic links in `~/.kiro/powers/installed/kiro-protocols/`
-  - Automatic registration in `~/.kiro/powers/registry.json`
+  - Physical copy in `~/.kiro/powers/installed/kiro-protocols/`
+  - Automatic registration in `~/.kiro/powers/installed.json` and `registries/user-added.json`
   - Appears immediately as "installed" in Kiro Powers UI
 
 **Build Process**:
 1. Build powers: `bun run build:powers` (uses manifest to auto-discover and process protocols to `powers/kiro-protocols/`)
 2. Build npm: `bun run build` (compiles CLI, processes steering via manifest, copies power files from `powers/`)
 3. CLI installs both steering and power during `npx kiro-agents`
-4. CLI creates symbolic links and registers power automatically
+4. CLI copies power files physically and registers power automatically
 
 **Why Dual Installation**:
 - Protocols discoverable in Kiro Powers UI
@@ -183,7 +183,7 @@ npx kiro-agents  # or bunx kiro-agents
 2. Interactive wizard activates (chit-chat protocol)
 3. User chooses "Create new agent"
 4. Wizard guides through agent creation
-5. Agent file created in `.kiro/agents/{name}.md`
+5. Agent file created in `.kiro/kiro-agents/{name}.md`
 6. User can activate with `/agents {name}`
 
 ### Switching Modes
@@ -237,7 +237,7 @@ npx kiro-agents  # or bunx kiro-agents
 **Required patterns**:
 - ✅ Use substitutions for IDE-specific values: `{{{WS_AGENTS_PATH}}}`, `{{{INITIAL_AGENT_NAME}}}`
 - ✅ Generic terminology: "IDE" instead of "Kiro IDE"
-- ✅ Generic paths: `.ai-agents/agents` (base) → `.kiro/agents` (Kiro override)
+- ✅ Generic paths: `.ai-agents/agents` (base) → `.kiro/kiro-agents` (Kiro override)
 - ✅ Generic names: `project-master` (base) → `kiro-master` (Kiro override)
 
 **Build system architecture**:

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -157,8 +157,8 @@ kiro-agents/
 - Uses `getSteeringFilesForCLI()` and `getPowerFilesForCLI()` from manifest
 - Installs core system files to `~/.kiro/steering/kiro-agents/`
 - Installs protocol library to `~/.kiro/powers/kiro-protocols/`
-- Creates symbolic links in `~/.kiro/powers/installed/kiro-protocols/`
-- Automatic power registration in `~/.kiro/powers/registry.json`
+- Copies power files physically to `~/.kiro/powers/installed/kiro-protocols/`
+- Automatic power registration in `~/.kiro/powers/installed.json` and `registries/user-added.json`
 - Removes old installations before installing new
 - Manages file permissions
 - Cross-platform compatible

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -66,8 +66,8 @@
 - Executable via `npx` and `bunx`
 - Dual installation: steering files + kiro-protocols power
 - Installs to: `~/.kiro/steering/kiro-agents/` and `~/.kiro/powers/kiro-protocols/`
-- Creates symbolic links in `~/.kiro/powers/installed/kiro-protocols/`
-- Automatic power registration in `~/.kiro/powers/registry.json`
+- Copies power files physically to `~/.kiro/powers/installed/kiro-protocols/`
+- Automatic power registration in `~/.kiro/powers/installed.json` and `registries/user-added.json`
 - Power appears immediately as "installed" in Kiro Powers UI
 - Cross-platform CLI tool
 - Removes old installation before installing new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ kiro-agents/
 ✅ **Required:**
 - Use substitutions: `{{{WS_AGENTS_PATH}}}`, `{{{INITIAL_AGENT_NAME}}}`
 - Generic terminology: "IDE" instead of "Kiro IDE"
-- Generic paths: `.ai-agents/agents` (base) → `.kiro/agents` (Kiro override)
+- Generic paths: `.ai-agents/agents` (base) → `.kiro/kiro-agents` (Kiro override)
 
 ## Versioning System
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Automatically installed alongside kiro-agents, this Power provides protocols (ag
 Protocols load only when needed, keeping your context clean. Base system uses just 1.35K tokens.
 
 **Your Agents, Your Files**
-Agents you create are saved as `.md` files in `.kiro/agents/`. Edit them like any document, version control them with git, reuse them across projects.
+Agents you create are saved as `.md` files in `.kiro/kiro-agents/`. Edit them like any document, version control them with git, reuse them across projects.
 
 ## Documentation
 

--- a/bin/cli.template.ts
+++ b/bin/cli.template.ts
@@ -3,7 +3,7 @@
  * kiro-agents CLI installer
  * 
  * Dual-installation system that installs both steering documents and kiro-protocols power
- * to user's home directory. Automatically registers power in Kiro's registry for immediate use.
+ * to user's home directory. Automatically registers power for immediate use in Kiro IDE.
  * Removes old installations before installing new versions.
  * 
  * **File Lists Generated from Manifest:**
@@ -11,13 +11,14 @@
  * to ensure consistency across all build targets (npm, dev, cli).
  * 
  * Installation targets:
- * - Steering: ~/.kiro/steering/kiro-agents/ (core system files)
- * - Power: ~/.kiro/powers/kiro-protocols/ (protocol library power)
- * - Symlinks: ~/.kiro/powers/installed/kiro-protocols/ (points to power files)
- * - Registry: ~/.kiro/powers/registry.json (automatic registration)
+ * - Steering: ~/.kiro/steering/kiro-agents/ (core system files, read-only)
+ * - Power source: ~/.kiro/powers/kiro-protocols/ (protocol library, writable — used as source by Kiro IDE)
+ * - Power installed: ~/.kiro/powers/installed/kiro-protocols/ (physical copy — used by Kiro IDE at runtime)
+ * - Registry: ~/.kiro/powers/installed.json + ~/.kiro/powers/registries/user-added.json
  * 
- * The CLI installs power files and registers them in registry.json following Kiro's
- * exact pattern for local power installations. Power appears as "installed" in Powers UI.
+ * The CLI replicates exactly what Kiro IDE does when a user installs a power via
+ * "Add Custom Power" in the Powers UI. Power appears as "installed" in Powers UI
+ * immediately after running npx kiro-agents.
  * 
  * @example
  * ```bash
@@ -42,23 +43,48 @@ const __dirname = dirname(__filename);
 /** Installation directory for steering documents (e.g., '~/.kiro/steering/kiro-agents') */
 const STEERING_INSTALL_DIR = join(homedir(), ".kiro", "steering", "kiro-agents");
 
-/** Installation directory for kiro-protocols power (e.g., '~/.kiro/powers/kiro-protocols') */
+/**
+ * Source directory for kiro-protocols power files (e.g., '~/.kiro/powers/kiro-protocols').
+ * 
+ * Files here are kept writable so Kiro IDE can read them as a source when needed.
+ * Registered as `source.path` in `registries/user-added.json`.
+ * 
+ * @see registerPower - Registers this path as source in user-added registry
+ */
 const POWER_INSTALL_DIR = join(homedir(), ".kiro", "powers", "kiro-protocols");
 
 /**
- * Installation directory for Kiro's installed power symlinks (e.g., '~/.kiro/powers/installed/kiro-protocols').
+ * Runtime directory for kiro-protocols power files (e.g., '~/.kiro/powers/installed/kiro-protocols').
  * 
- * Kiro IDE expects installed powers to have symlinks in this directory pointing to the actual
- * power files in POWER_INSTALL_DIR. The CLI creates these symlinks during installation to match
- * Kiro's pattern for local power installations.
+ * Contains a physical copy of the power files (no symlinks). This is where Kiro IDE
+ * reads the power from at runtime. Populated by installPowerFiles() during installation,
+ * replicating what Kiro IDE does when a user installs via "Add Custom Power" UI.
  * 
- * @see createSymbolicLinks - Creates symlinks in this directory
- * @see registerPowerInRegistry - Registers this path as installPath in registry
+ * Files here are set to read-only after copying, matching Kiro IDE's behavior.
+ * 
+ * @see installPowerFiles - Copies files from POWER_INSTALL_DIR to this directory
  */
 const POWER_INSTALLED_DIR = join(homedir(), ".kiro", "powers", "installed", "kiro-protocols");
 
-/** Kiro powers registry file path (e.g., '~/.kiro/powers/registry.json') */
-const REGISTRY_PATH = join(homedir(), ".kiro", "powers", "registry.json");
+/**
+ * Path to Kiro's installed powers manifest (e.g., '~/.kiro/powers/installed.json').
+ * 
+ * Tracks which powers are installed and which registry they belong to.
+ * The CLI adds kiro-protocols with registryId "user-added" to this file.
+ * 
+ * @see registerPower - Writes to this file during installation
+ */
+const INSTALLED_JSON_PATH = join(homedir(), ".kiro", "powers", "installed.json");
+
+/**
+ * Path to Kiro's user-added powers registry (e.g., '~/.kiro/powers/registries/user-added.json').
+ * 
+ * Tracks custom powers added by the user, including their source paths.
+ * The CLI adds kiro-protocols with source.type "local" pointing to POWER_INSTALL_DIR.
+ * 
+ * @see registerPower - Writes to this file during installation
+ */
+const USER_ADDED_JSON_PATH = join(homedir(), ".kiro", "powers", "registries", "user-added.json");
 
 /**
  * Steering files to install from dist/ directory in package.
@@ -102,7 +128,7 @@ const STEERING_FILES = /* STEERING_FILES_PLACEHOLDER */ as const;
 const POWER_FILES = /* POWER_FILES_PLACEHOLDER */ as const;
 
 /**
- * Power metadata extracted from POWER.md frontmatter for registry registration.
+ * Power metadata extracted from POWER.md frontmatter.
  * 
  * @property name - Power identifier (e.g., 'kiro-protocols')
  * @property displayName - Human-readable name shown in Powers UI (e.g., 'Kiro Protocols')
@@ -119,75 +145,38 @@ interface PowerMetadata {
 }
 
 /**
- * Kiro registry structure for tracking installed powers.
+ * Structure of ~/.kiro/powers/installed.json.
  * 
- * Located at `~/.kiro/powers/registry.json`, maintains state of all powers
- * installed in Kiro IDE for Powers UI integration.
+ * Tracks which powers are installed and which registry entry describes them.
+ * Kiro IDE reads this file on startup to determine installed powers.
  * 
- * @property version - Registry format version (e.g., '1.0.0')
- * @property powers - Map of power name to power entry
- * @property repoSources - Map of repo ID to repository source
- * @property lastUpdated - ISO timestamp of last registry modification
+ * @property version - File format version
+ * @property installedPowers - List of installed power entries
+ * @property dismissedAutoInstalls - Powers the user has dismissed from auto-install prompts
  */
-interface KiroRegistry {
+interface InstalledPowers {
   version: string;
-  powers: Record<string, PowerEntry>;
-  repoSources: Record<string, RepoSource>;
-  lastUpdated: string;
+  installedPowers: Array<{ name: string; registryId: string }>;
+  dismissedAutoInstalls: string[];
 }
 
 /**
- * Power entry in the registry representing an installed or available power.
+ * Structure of ~/.kiro/powers/registries/user-added.json.
  * 
- * @property name - Power identifier
- * @property displayName - Human-readable name
- * @property description - Power capabilities description
- * @property mcpServers - MCP server names provided by power (empty for kiro-protocols)
- * @property author - Power author/maintainer
- * @property keywords - Search terms for discovery
- * @property installed - Whether power is currently installed
- * @property installedAt - ISO timestamp of installation (if installed)
- * @property installPath - Path to symlink directory in installed/ (if installed)
- * @property source - Repository source information
- * @property sourcePath - Path to actual power directory (if installed)
- */
-interface PowerEntry {
-  name: string;
-  displayName: string;
-  description: string;
-  mcpServers: string[];
-  author: string;
-  keywords: string[];
-  installed: boolean;
-  installedAt?: string;
-  installPath?: string;
-  source: {
-    type: string;
-    repoId: string;
-    repoName: string;
-  };
-  sourcePath?: string;
-}
-
-/**
- * Repository source entry tracking power source locations.
+ * Registry of custom powers added by the user via "Add Custom Power" UI or CLI.
+ * Kiro IDE reads this to find the source path for each user-added power.
  * 
- * @property name - Repository display name (full path for local repos)
- * @property type - Source type ('local' for filesystem, 'git' for remote)
- * @property enabled - Whether source is active for power discovery
- * @property addedAt - ISO timestamp when source was added
- * @property path - Filesystem path to repository
- * @property lastSync - ISO timestamp of last synchronization
- * @property powerCount - Number of powers available from this source
+ * @property powers - List of user-added power entries with source information
  */
-interface RepoSource {
-  name: string;
-  type: string;
-  enabled: boolean;
-  addedAt: string;
-  path: string;
-  lastSync: string;
-  powerCount: number;
+interface UserAddedRegistry {
+  powers: Array<{
+    name: string;
+    description: string;
+    source: {
+      type: string;
+      path: string;
+    };
+  }>;
 }
 
 /**
@@ -245,7 +234,7 @@ async function setReadOnly(filePath: string): Promise<void> {
  * @example
  * ```typescript
  * const metadata = await extractPowerMetadata('/path/to/POWER.md');
- * // { name: 'kiro-protocols', displayName: 'Kiro Protocols', 
+ * // { name: 'kiro-protocols', displayName: 'Kiro Protocols',
  * //   description: '...', keywords: [...], author: '...' }
  * ```
  */
@@ -283,18 +272,17 @@ async function extractPowerMetadata(powerMdPath: string): Promise<PowerMetadata>
 }
 
 /**
- * Recursively copies a file or directory.
+ * Recursively copies a file or directory, preserving directory structure.
  * 
- * Used as fallback when symbolic links cannot be created (e.g., Windows without admin).
- * Preserves directory structure and copies all files recursively.
+ * Used internally by `installPowerFiles` to copy subdirectories (e.g., `steering/`).
  * 
  * @param src - Source path (file or directory)
  * @param dest - Destination path
  * 
  * @example
  * ```typescript
- * await copyRecursive('/source/dir', '/dest/dir');
- * // Copies all files and subdirectories
+ * await copyRecursive('/source/steering', '/dest/steering');
+ * // Copies all .md files preserving subdirectory layout
  * ```
  */
 async function copyRecursive(src: string, dest: string): Promise<void> {
@@ -303,195 +291,161 @@ async function copyRecursive(src: string, dest: string): Promise<void> {
   const stats = await stat(src);
   
   if (stats.isDirectory()) {
-    // Create destination directory
     await mkdir(dest, { recursive: true });
-    
-    // Copy all entries recursively
     const entries = await readdir(src);
     for (const entry of entries) {
       await copyRecursive(join(src, entry), join(dest, entry));
     }
   } else {
-    // Copy file
     await copyFile(src, dest);
   }
 }
 
 /**
- * Creates symbolic links in installed/ directory pointing to power files.
+ * Copies power files from POWER_INSTALL_DIR to POWER_INSTALLED_DIR as physical files.
  * 
- * Kiro IDE expects installed powers to be in ~/.kiro/powers/installed/{power-name}/
- * with symbolic links pointing to the actual files in ~/.kiro/powers/{power-name}/.
+ * Replicates what Kiro IDE does when a user installs a power via "Add Custom Power" UI:
+ * copies all files (except `icon.png`, which Kiro IDE skips) from the source directory
+ * to the `installed/` directory as real files, then sets them read-only.
+ * 
+ * This is NOT a symlink operation. Kiro IDE reads from `installed/` directly at runtime
+ * and does not auto-repair this directory if it is missing or corrupted.
  * 
  * Process:
- * 1. Removes existing installed directory if present
- * 2. Creates new installed directory
- * 3. Creates symbolic links for each file and directory in power directory
- * 4. Falls back to copying files if symlink creation fails (Windows without admin)
+ * 1. Removes existing installed directory if present (clean install)
+ * 2. Copies all entries from POWER_INSTALL_DIR except `icon.png`
+ * 3. For files: copies and sets read-only immediately
+ * 4. For directories (e.g., `steering/`): copies recursively, then sets top-level entries read-only
  * 
- * Platform-specific behavior:
- * - Windows: Uses junction for directories, symlink for files (requires admin)
- * - Windows fallback: Copies files if symlink fails (no admin required)
- * - Unix: Uses symbolic links for both files and directories
- * 
- * @returns Number of warnings encountered (0 = success, >0 = partial success)
+ * **Note:** Read-only is applied to direct children of subdirectories only (one level deep).
+ * Deeply nested files are copied but not explicitly chmod'd.
  * 
  * @example
  * ```typescript
- * const warnings = await createSymbolicLinks();
- * // Creates ~/.kiro/powers/installed/kiro-protocols/ with symlinks to:
- * // - POWER.md -> ../../kiro-protocols/POWER.md
- * // - mcp.json -> ../../kiro-protocols/mcp.json
- * // - icon.png -> ../../kiro-protocols/icon.png
- * // - steering/ -> ../../kiro-protocols/steering/
- * // Or copies files if symlink fails
+ * await installPowerFiles();
+ * // Creates ~/.kiro/powers/installed/kiro-protocols/ with:
+ * // - POWER.md (read-only)
+ * // - mcp.json (read-only)
+ * // - steering/*.md (read-only)
+ * // icon.png is intentionally excluded (Kiro IDE does not copy it)
  * ```
  */
-async function createSymbolicLinks(): Promise<number> {
-  const { readdir, mkdir, symlink, rm, stat } = await import("fs/promises");
-  const { platform } = await import("os");
+async function installPowerFiles(): Promise<void> {
+  const { readdir, mkdir, rm, stat, copyFile } = await import("fs/promises");
   
-  let warningCount = 0;
-  
-  // Remove existing installed directory
+  // Remove existing installed directory for clean install
   if (existsSync(POWER_INSTALLED_DIR)) {
     await rm(POWER_INSTALLED_DIR, { recursive: true, force: true });
   }
-  
-  // Create installed directory
   await mkdir(POWER_INSTALLED_DIR, { recursive: true });
   
-  // Get all files and directories in power directory
+  // Copy all entries from source except icon.png (Kiro IDE does not copy it)
   const entries = await readdir(POWER_INSTALL_DIR);
-  
-  // Create symbolic links for each entry
   for (const entry of entries) {
-    const sourcePath = join(POWER_INSTALL_DIR, entry);
-    const targetPath = join(POWER_INSTALLED_DIR, entry);
+    if (entry === "icon.png") continue;
     
-    try {
-      // Check if entry is directory
-      const stats = await stat(sourcePath);
-      const isDirectory = stats.isDirectory();
-      
-      // Windows requires different link types
-      if (platform() === "win32") {
-        // Use junction for directories, symlink for files
-        await symlink(sourcePath, targetPath, isDirectory ? "junction" : "file");
-      } else {
-        // Unix uses symlink for both
-        await symlink(sourcePath, targetPath);
+    const srcPath = join(POWER_INSTALL_DIR, entry);
+    const destPath = join(POWER_INSTALLED_DIR, entry);
+    const stats = await stat(srcPath);
+    
+    if (stats.isDirectory()) {
+      // Recursively copy subdirectory (e.g., steering/)
+      await copyRecursive(srcPath, destPath);
+      // Set all files in subdirectory to read-only
+      const subEntries = await readdir(destPath);
+      for (const subEntry of subEntries) {
+        await setReadOnly(join(destPath, subEntry));
       }
-      
-      console.log(`✅ Linked: ${entry}`);
-    } catch (error) {
-      // Fallback to copying if symlink fails (Windows without admin)
-      try {
-        await copyRecursive(sourcePath, targetPath);
-        console.log(`📋 Copied: ${entry} (symlink not available)`);
-      } catch (copyError) {
-        console.warn(`⚠️  Could not link or copy ${entry}:`, error instanceof Error ? error.message : error);
-        warningCount++;
-      }
+    } else {
+      await copyFile(srcPath, destPath);
+      await setReadOnly(destPath);
     }
+    
+    console.log(`✅ Installed: ${entry}`);
   }
-  
-  return warningCount;
 }
 
 /**
- * Registers the kiro-protocols power in Kiro's registry.json.
+ * Registers kiro-protocols in Kiro's power registry files.
  * 
- * Follows the exact pattern used by Kiro IDE for local power installations.
- * The power is registered with a stable repoId and proper paths to ensure
- * it appears as "installed" in Kiro's Powers UI.
+ * Replicates exactly what Kiro IDE does when a user installs a power via
+ * "Add Custom Power" UI. Writes to two files:
  * 
- * Process:
- * 1. Ensures registry directory exists (~/.kiro/powers/)
- * 2. Reads existing registry or creates new one
- * 3. Extracts power metadata from POWER.md frontmatter
- * 4. Creates/updates power entry with installation info
- * 5. Creates/updates local repo source entry
- * 6. Saves updated registry with timestamp
+ * 1. `~/.kiro/powers/installed.json` — marks kiro-protocols as installed
+ *    with registryId "user-added". Merges with existing entries (idempotent).
  * 
- * Registry structure follows Kiro's pattern:
- * - Power entry uses installPath pointing to installed/ directory
- * - Power entry uses sourcePath pointing to actual power directory
- * - Repo source uses stable ID "local-kiro-protocols" (no timestamp)
- * - Source type is "repo" (not "local") for proper UI integration
+ * 2. `~/.kiro/powers/registries/user-added.json` — records the source path
+ *    (`POWER_INSTALL_DIR`) so Kiro IDE knows where the power came from.
+ *    Updates existing entry if present, otherwise appends.
+ * 
+ * Does NOT modify `~/.kiro/powers/registry.json` — that file is the marketplace
+ * catalog managed exclusively by Kiro IDE.
  * 
  * @returns True if successful, false if failed
  * 
- * @example
+ * @example Register on fresh install
  * ```typescript
- * const success = await registerPowerInRegistry();
- * // Power registered in registry.json
- * // Appears as installed in Kiro Powers UI
+ * const success = await registerPower();
+ * // Writes to installed.json and registries/user-added.json
+ * // Power appears as installed in Kiro Powers UI
+ * ```
+ * 
+ * @example Re-running is safe (idempotent)
+ * ```typescript
+ * await registerPower(); // first install
+ * await registerPower(); // update — merges, no duplicates
  * ```
  */
-async function registerPowerInRegistry(): Promise<boolean> {
+async function registerPower(): Promise<boolean> {
   const { readFile, writeFile, mkdir } = await import("fs/promises");
   
-  // Ensure registry directory exists
-  const registryDir = dirname(REGISTRY_PATH);
-  await mkdir(registryDir, { recursive: true });
+  // Ensure registries directory exists
+  await mkdir(dirname(USER_ADDED_JSON_PATH), { recursive: true });
   
-  // Read existing registry or create new one
-  let registry: KiroRegistry;
-  if (existsSync(REGISTRY_PATH)) {
-    const content = await readFile(REGISTRY_PATH, "utf-8");
-    registry = JSON.parse(content);
+  // --- installed.json ---
+  let installed: InstalledPowers;
+  if (existsSync(INSTALLED_JSON_PATH)) {
+    const content = await readFile(INSTALLED_JSON_PATH, "utf-8");
+    installed = JSON.parse(content);
   } else {
-    registry = {
-      version: "1.0.0",
-      powers: {},
-      repoSources: {},
-      lastUpdated: new Date().toISOString(),
-    };
+    installed = { version: "1.0.0", installedPowers: [], dismissedAutoInstalls: [] };
   }
   
-  // Extract metadata from POWER.md
-  const powerMdPath = join(POWER_INSTALL_DIR, "POWER.md");
-  const metadata = await extractPowerMetadata(powerMdPath);
+  // Add kiro-protocols entry if not already present
+  const alreadyInstalled = installed.installedPowers.some(p => p.name === "kiro-protocols");
+  if (!alreadyInstalled) {
+    installed.installedPowers.push({ name: "kiro-protocols", registryId: "user-added" });
+  }
+  await writeFile(INSTALLED_JSON_PATH, JSON.stringify(installed, null, 2), "utf-8");
   
-  // Use stable repo ID (matches Kiro's pattern for local powers)
-  const repoId = "local-kiro-protocols";
+  // --- registries/user-added.json ---
+  let userAdded: UserAddedRegistry;
+  if (existsSync(USER_ADDED_JSON_PATH)) {
+    const content = await readFile(USER_ADDED_JSON_PATH, "utf-8");
+    userAdded = JSON.parse(content);
+  } else {
+    userAdded = { powers: [] };
+  }
   
-  // Create/update power entry (following Kiro's exact pattern)
-  registry.powers[metadata.name] = {
-    name: metadata.name,
-    displayName: metadata.displayName,
-    description: metadata.description,
-    mcpServers: [], // kiro-protocols has no MCP servers
-    author: metadata.author,
-    keywords: metadata.keywords,
-    installed: true,
-    installedAt: new Date().toISOString(),
-    installPath: POWER_INSTALLED_DIR, // Points to installed/ directory with symlinks
+  // Extract description from POWER.md for the registry entry (currently unused — description is derived from path)
+  // const metadata = await extractPowerMetadata(powerMdPath); // reserved for future use
+  
+  // Update or add kiro-protocols entry
+  const existingIdx = userAdded.powers.findIndex(p => p.name === "kiro-protocols");
+  const entry = {
+    name: "kiro-protocols",
+    description: `Custom power from ${POWER_INSTALL_DIR}`,
     source: {
-      type: "repo", // Changed from "local" to match Kiro's pattern
-      repoId: repoId,
-      repoName: POWER_INSTALL_DIR, // Full path to actual power directory
+      type: "local",
+      path: POWER_INSTALL_DIR,
     },
-    sourcePath: POWER_INSTALL_DIR, // Points to actual power directory
   };
-  
-  // Create/update repo source entry (following Kiro's exact pattern)
-  registry.repoSources[repoId] = {
-    name: POWER_INSTALL_DIR, // Full path as name
-    type: "local",
-    enabled: true,
-    addedAt: new Date().toISOString(),
-    path: POWER_INSTALL_DIR,
-    lastSync: new Date().toISOString(),
-    powerCount: 1,
-  };
-  
-  // Update lastUpdated timestamp
-  registry.lastUpdated = new Date().toISOString();
-  
-  // Save registry
-  await writeFile(REGISTRY_PATH, JSON.stringify(registry, null, 2), "utf-8");
+  if (existingIdx >= 0) {
+    userAdded.powers[existingIdx] = entry;
+  } else {
+    userAdded.powers.push(entry);
+  }
+  await writeFile(USER_ADDED_JSON_PATH, JSON.stringify(userAdded, null, 2), "utf-8");
   
   console.log("✅ Power registered in Kiro registry");
   return true;
@@ -501,29 +455,30 @@ async function registerPowerInRegistry(): Promise<boolean> {
  * Installs a single file from package to target directory.
  * 
  * Process:
- * 1. Restores write permissions if file exists
+ * 1. Restores write permissions if file exists (for updates)
  * 2. Reads source file from package
  * 3. Creates destination directory if needed
  * 4. Writes file to destination
- * 5. Sets file to read-only
+ * 5. Sets file to read-only (steering files only — power source files stay writable)
  * 
  * @param relativePath - Path relative to source directory (e.g., 'agents.md', 'steering/agent-activation.md')
  * @param installDir - Absolute installation directory (e.g., '~/.kiro/steering/kiro-agents')
  * @param sourceDir - Source directory in package (e.g., 'dist', 'power')
+ * @param readOnly - Whether to set the file read-only after install (default: true)
  * 
  * @example
  * ```typescript
- * // Install steering file
+ * // Install steering file (read-only)
  * await installFile('agents.md', STEERING_INSTALL_DIR, 'dist');
  * 
- * // Install power file
- * await installFile('steering/agent-activation.md', POWER_INSTALL_DIR, 'power');
+ * // Install power source file (writable — Kiro IDE needs to read it as source)
+ * await installFile('steering/agent-activation.md', POWER_INSTALL_DIR, 'power', false);
  * ```
  */
-async function installFile(relativePath: string, installDir: string, sourceDir: string): Promise<void> {
+async function installFile(relativePath: string, installDir: string, sourceDir: string, readOnly = true): Promise<void> {
   const destPath = join(installDir, relativePath);
   
-  // Restore write permissions if file exists
+  // Restore write permissions if file exists (needed for updates)
   if (existsSync(destPath)) {
     await setWritable(destPath);
   }
@@ -531,7 +486,6 @@ async function installFile(relativePath: string, installDir: string, sourceDir: 
   // Get source file from package
   const srcPath = join(__dirname, "..", sourceDir, relativePath);
   
-  // Read file using fs for Node.js compatibility
   const { readFile, writeFile, mkdir } = await import("fs/promises");
   const content = await readFile(srcPath);
   
@@ -539,11 +493,11 @@ async function installFile(relativePath: string, installDir: string, sourceDir: 
   const destDir = dirname(destPath);
   await mkdir(destDir, { recursive: true });
   
-  // Write file
   await writeFile(destPath, content);
   
-  // Set read-only
-  await setReadOnly(destPath);
+  if (readOnly) {
+    await setReadOnly(destPath);
+  }
   
   console.log(`✅ Installed: ${relativePath}`);
 }
@@ -553,28 +507,14 @@ async function installFile(relativePath: string, installDir: string, sourceDir: 
  * 
  * Installation process:
  * 1. Removes existing steering installation if present
- * 2. Installs steering files to ~/.kiro/steering/kiro-agents/
- * 3. Removes existing power installation if present
- * 4. Installs power files to ~/.kiro/powers/kiro-protocols/
- * 5. Creates symbolic links in ~/.kiro/powers/installed/kiro-protocols/
- * 6. Registers kiro-protocols in ~/.kiro/powers/registry.json
- * 7. Sets all files to read-only
+ * 2. Installs steering files to ~/.kiro/steering/kiro-agents/ (read-only)
+ * 3. Removes existing power source installation if present
+ * 4. Installs power files to ~/.kiro/powers/kiro-protocols/ (writable — source directory)
+ * 5. Copies power files to ~/.kiro/powers/installed/kiro-protocols/ (read-only — runtime directory)
+ * 6. Registers kiro-protocols in installed.json and registries/user-added.json
  * 
- * Steering files include core system files that provide foundational kiro-agents
- * functionality including instruction aliases, agent management, mode switching,
- * strict mode control, and interaction patterns.
- * 
- * Power files include:
- * - Power metadata (POWER.md, mcp.json, icon.png)
- * - Protocol files (agent-activation.md, agent-creation.md, etc.)
- * 
- * Registry registration follows Kiro's exact pattern:
- * - Stable repoId: "local-kiro-protocols"
- * - installPath points to symlink directory
- * - sourcePath points to actual power directory
- * - Power appears as "installed" in Powers UI
- * 
- * Tracks errors and warnings to provide accurate installation status.
+ * This replicates exactly what Kiro IDE does when a user installs a power via
+ * "Add Custom Power" UI, ensuring compatibility with current and future Kiro versions.
  * 
  * @throws {Error} If installation fails (caught by main execution handler)
  * 
@@ -588,76 +528,64 @@ async function installFile(relativePath: string, installDir: string, sourceDir: 
 async function install(): Promise<void> {
   console.log("🚀 Installing kiro-agents system...\n");
   
-  let hasErrors = false;
   let hasWarnings = false;
   
-  // Install steering files
+  // --- Steering files ---
   console.log("📄 Installing steering files to ~/.kiro/steering/kiro-agents/");
   if (existsSync(STEERING_INSTALL_DIR)) {
     console.log("🗑️  Removing existing steering installation...");
     const { rmSync } = await import("fs");
     rmSync(STEERING_INSTALL_DIR, { recursive: true, force: true });
   }
-  
   for (const file of STEERING_FILES) {
     await installFile(file, STEERING_INSTALL_DIR, "dist");
   }
   
-  // Install power files
-  console.log("\n⚡ Installing kiro-protocols power to ~/.kiro/powers/kiro-protocols/");
+  // --- Power source files (writable) ---
+  console.log("\n⚡ Installing kiro-protocols source to ~/.kiro/powers/kiro-protocols/");
   if (existsSync(POWER_INSTALL_DIR)) {
-    console.log("🗑️  Removing existing power installation...");
+    console.log("🗑️  Removing existing power source...");
     const { rmSync } = await import("fs");
     rmSync(POWER_INSTALL_DIR, { recursive: true, force: true });
   }
-  
   for (const file of POWER_FILES) {
-    await installFile(file, POWER_INSTALL_DIR, "power");
+    await installFile(file, POWER_INSTALL_DIR, "power", false);
   }
   
-  // Create symbolic links in installed/ directory
-  console.log("\n🔗 Creating symbolic links in installed/ directory...");
+  // --- Power installed files (physical copy, read-only) ---
+  console.log("\n📋 Copying power files to ~/.kiro/powers/installed/kiro-protocols/");
   try {
-    const symlinkWarnings = await createSymbolicLinks();
-    if (symlinkWarnings > 0) {
-      hasWarnings = true;
-    }
+    await installPowerFiles();
   } catch (error) {
-    console.warn("⚠️  Warning: Could not create symbolic links:", error instanceof Error ? error.message : error);
+    console.warn("⚠️  Warning: Could not copy power files to installed/:", error instanceof Error ? error.message : error);
     console.warn("   Power may not appear correctly in Kiro Powers UI.");
     hasWarnings = true;
   }
   
-  // Register power in Kiro registry
+  // --- Registry registration ---
   console.log("\n📝 Registering power in Kiro registry...");
   try {
-    const registrySuccess = await registerPowerInRegistry();
-    if (!registrySuccess) {
-      hasWarnings = true;
-    }
+    await registerPower();
   } catch (error) {
-    console.warn("⚠️  Warning: Could not register power in registry:", error instanceof Error ? error.message : error);
+    console.warn("⚠️  Warning: Could not register power:", error instanceof Error ? error.message : error);
     console.warn("   The power files are installed but may not appear in Kiro Powers UI.");
-    console.warn("   You can manually add the power via: Powers panel → Add Repository → Local Directory");
+    console.warn("   You can manually add the power via: Powers panel → Add Custom Power → Local Directory");
     console.warn(`   Path: ${POWER_INSTALL_DIR}`);
     hasWarnings = true;
   }
   
-  // Final status message
-  if (hasErrors) {
-    console.log("\n❌ Installation completed with errors!");
-  } else if (hasWarnings) {
+  // Final status
+  if (hasWarnings) {
     console.log("\n⚠️  Installation completed with warnings!");
     console.log("   Core files installed successfully, but some optional features may not work.");
   } else {
     console.log("\n✨ Installation completed successfully!");
   }
   
-  console.log(`\n📁 Steering files: ${STEERING_INSTALL_DIR}`);
-  console.log(`📁 Power files: ${POWER_INSTALL_DIR}`);
-  console.log(`📁 Installed links: ${POWER_INSTALLED_DIR}`);
+  console.log(`\n📁 Steering files:  ${STEERING_INSTALL_DIR}`);
+  console.log(`📁 Power source:    ${POWER_INSTALL_DIR}`);
+  console.log(`📁 Power installed: ${POWER_INSTALLED_DIR}`);
   console.log("\n💡 The kiro-protocols power should now appear as installed in Kiro Powers UI.");
-  console.log("💡 Files are set to read-only. To modify them, change permissions first.");
   console.log("\n🔄 To update, simply run 'npx kiro-agents' again.");
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -249,8 +249,8 @@ npx kiro-agents  # or bunx kiro-agents
 **2. kiro-protocols Power** → `~/.kiro/powers/kiro-protocols/`
 - Power metadata (POWER.md, mcp.json, icon.png)
 - Protocol files in steering/ subdirectory
-- Symbolic links in `~/.kiro/powers/installed/kiro-protocols/`
-- Automatic registration in `~/.kiro/powers/registry.json`
+- Physical copy in `~/.kiro/powers/installed/kiro-protocols/`
+- Automatic registration in `~/.kiro/powers/installed.json` and `registries/user-added.json`
 
 **Why Dual Installation:**
 - Protocols discoverable in Kiro Powers UI
@@ -290,7 +290,7 @@ User Installation
 
 ### Architecture
 
-**Agent Definition Files:** `.kiro/agents/{name}.md`
+**Agent Definition Files:** `.kiro/kiro-agents/{name}.md`
 
 **Components:**
 1. **Frontmatter** - Metadata (name, type, description, version)
@@ -308,7 +308,7 @@ User Installation
 - Agent management protocol loads
 - User selects creation method (Quick Start, Project-Specific, etc.)
 - AI generates agent definition based on user input
-- Agent file saved to `.kiro/agents/{name}.md`
+- Agent file saved to `.kiro/kiro-agents/{name}.md`
 
 **2. Activation**
 - User invokes `/agents {name}`
@@ -336,7 +336,7 @@ User Installation
 <alias>
   <trigger>/agents {agent_name}</trigger>
   <definition>
-1. Read `.kiro/agents/{agent_name}.md` into context
+1. Read `.kiro/kiro-agents/{agent_name}.md` into context
 2. /only-read-protocols agent-activation.md
 3. Follow agent activation steps
   </definition>
@@ -610,7 +610,7 @@ User Installation:
 
 Workspace-Specific:
 
-{workspace}/.kiro/agents/
+{workspace}/.kiro/kiro-agents/
 └── {user-created-agents}.md
 ```
 
@@ -633,7 +633,7 @@ AI loads: chit-chat.md protocol (via kiroPowers)
     ↓
 AI loads: agent-management.md protocol (via kiroPowers)
     ↓
-AI scans: .kiro/agents/ directory
+AI scans: .kiro/kiro-agents/ directory
     ↓
 AI presents: Numbered choices (create, activate, manage, etc.)
     ↓
@@ -650,7 +650,7 @@ AI executes: Open-ended generation
     ├── Generates optimal agent architecture
     └── Creates agent definition
     ↓
-AI writes: .kiro/agents/{name}.md
+AI writes: .kiro/kiro-agents/{name}.md
     ↓
 AI offers: Activate new agent?
 ```
@@ -664,7 +664,7 @@ AI detects: Instruction alias in aliases.md (always loaded)
     ↓
 AI detects: Parameter provided, activation mode
     ↓
-AI loads: .kiro/agents/{agent_name}.md
+AI loads: .kiro/kiro-agents/{agent_name}.md
     ↓
 AI loads: agent-activation.md protocol (via kiroPowers)
     ↓
@@ -770,7 +770,7 @@ User Installation (npx kiro-agents)
 ✅ **Required:**
 - Use substitutions: `{{{WS_AGENTS_PATH}}}`, `{{{INITIAL_AGENT_NAME}}}`
 - Generic terminology: "IDE" instead of "Kiro IDE"
-- Generic paths: `.ai-agents/agents` (base) → `.kiro/agents` (Kiro override)
+- Generic paths: `.ai-agents/agents` (base) → `.kiro/kiro-agents` (Kiro override)
 - Generic names: `project-master` (base) → `kiro-master` (Kiro override)
 
 ### Build System Architecture
@@ -853,7 +853,7 @@ User Installation (npx kiro-agents)
 ### Adding New Agents
 
 1. User creates agent via `/agents` command
-2. Agent file saved to `.kiro/agents/{name}.md`
+2. Agent file saved to `.kiro/kiro-agents/{name}.md`
 3. Immediately available for activation
 4. No system changes needed
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -127,7 +127,7 @@ You can create as many agents as you need:
 3. Choose your preferred creation method
 4. Repeat for each agent
 
-All agents are saved in `.kiro/agents/` and available across sessions.
+All agents are saved in `.kiro/kiro-agents/` and available across sessions.
 
 ### Refining Agents
 
@@ -225,7 +225,7 @@ Use strict mode for:
 **Agent not activating?**
 - Check the agent name: `/agents {exact-name}`
 - Use `/agents` to see available agents
-- Verify agent file exists in `.kiro/agents/`
+- Verify agent file exists in `.kiro/kiro-agents/`
 
 **Want to start over?**
 - Type `/agents`

--- a/docs/INSTALLED-ARCHITECTURE.md
+++ b/docs/INSTALLED-ARCHITECTURE.md
@@ -46,7 +46,7 @@ Both installations work together to provide the complete kiro-agents experience.
 
 **Agents:**
 - User-created specialized AI roles
-- Stored in workspace `.kiro/agents/` directory
+- Stored in workspace `.kiro/kiro-agents/` directory
 - Activated via `/agents {name}` command
 - Load protocols and steering documents as needed
 
@@ -66,7 +66,7 @@ Both installations work together to provide the complete kiro-agents experience.
 │   ├── strict.md                           # Strict mode control (inclusion: manual)
 │   └── reflect.md                          # Reflection system commands (inclusion: always)
 │
-├── powers/kiro-protocols/                  # Protocol library (actual files)
+├── powers/kiro-protocols/                  # Protocol library source (writable)
 │   ├── POWER.md                            # Power metadata
 │   ├── mcp.json                            # MCP configuration (empty)
 │   ├── icon.png                            # Power icon (512x512)
@@ -87,13 +87,17 @@ Both installations work together to provide the complete kiro-agents experience.
 │       ├── reflect-curator-checklist.md
 │       └── reflect-manager-workflow.md
 │
-├── powers/installed/kiro-protocols/        # Symbolic links (Kiro UI integration)
-│   ├── POWER.md -> ../../kiro-protocols/POWER.md
-│   ├── mcp.json -> ../../kiro-protocols/mcp.json
-│   ├── icon.png -> ../../kiro-protocols/icon.png
-│   └── steering/ -> ../../kiro-protocols/steering/
+├── powers/installed/kiro-protocols/        # Protocol library runtime copy (read-only)
+│   ├── POWER.md                            # Physical copy (no symlinks)
+│   ├── mcp.json                            # Physical copy
+│   └── steering/                           # Physical copy of all protocol files
+│       └── *.md
 │
-└── powers/registry.json                    # Power registry (automatic registration)
+├── powers/installed.json                   # Installed powers manifest
+├── powers/registries/
+│   └── user-added.json                     # User-added powers registry
+│
+└── powers/registry.json                    # Marketplace catalog (managed by Kiro IDE)
 
 {workspace}/.kiro/                          # Workspace-specific directory
 └── agents/                                 # User-created agents
@@ -115,21 +119,17 @@ Both installations work together to provide the complete kiro-agents experience.
 
 ### Why Two Power Directories?
 
-**`~/.kiro/powers/kiro-protocols/`** (Actual Files)
-- Contains the real power files
-- Where CLI installs the power
-- Source of truth for power content
+**`~/.kiro/powers/kiro-protocols/`** (Source — writable)
+- Contains the power files installed from the npm package
+- Kept writable so Kiro IDE can read it as a source directory
+- Registered as `source.path` in `registries/user-added.json`
+- Equivalent to the local path a user provides when adding a custom power via UI
 
-**`~/.kiro/powers/installed/kiro-protocols/`** (Symbolic Links)
-- Contains symlinks pointing to actual files
-- Used by Kiro IDE Powers UI
-- Follows Kiro's pattern for local power installations
-- Enables proper "installed" status in UI
-
-**Why this pattern?**
-- Kiro IDE expects installed powers in `installed/` directory
-- Allows separation between power source and UI integration
-- Enables proper registry tracking and UI display
+**`~/.kiro/powers/installed/kiro-protocols/`** (Runtime — read-only)
+- Physical copy of the power files (no symlinks, no icon.png)
+- Where Kiro IDE reads the power from at runtime
+- Created by the CLI replicating what Kiro IDE does during UI installation
+- Does NOT auto-repair if deleted — must be recreated by running `npx kiro-agents` again
 
 ---
 
@@ -182,11 +182,11 @@ Both installations work together to provide the complete kiro-agents experience.
 - Minimize base context overhead
 - Can be loaded multiple times if needed
 
-### Agent Files (`.kiro/agents/`)
+### Agent Files (`.kiro/kiro-agents/`)
 
 **Purpose:** User-created specialized AI agents
 
-**Location:** Workspace-specific (`.kiro/agents/` in each project)
+**Location:** Workspace-specific (`.kiro/kiro-agents/` in each project)
 
 **Structure:**
 ```markdown
@@ -211,7 +211,7 @@ version: 1.0.0
 
 **Lifecycle:**
 1. Created via `/agents` command (agent-creation.md protocol)
-2. Stored in workspace `.kiro/agents/` directory
+2. Stored in workspace `.kiro/kiro-agents/` directory
 3. Activated via `/agents {name}` command
 4. Modified via agent management interface
 
@@ -345,7 +345,7 @@ Step 5: Load Management Protocol
 └─ Agent management protocol now in context
 
 Step 6: Scan Workspace
-├─ AI scans .kiro/agents/ directory
+├─ AI scans .kiro/kiro-agents/ directory
 ├─ Finds existing agents (e.g., kiro-master.md)
 └─ Builds list of available agents
 
@@ -383,8 +383,8 @@ Step 1: Alias Detection
 
 Step 2: Alias Execution
 ├─ Alias definition:
-│   "Read .kiro/agents/{agent_name}.md into context"
-├─ AI reads: .kiro/agents/kiro-master.md
+│   "Read .kiro/kiro-agents/{agent_name}.md into context"
+├─ AI reads: .kiro/kiro-agents/kiro-master.md
 └─ Agent definition now in context
 
 Step 3: Load Activation Protocol
@@ -436,7 +436,7 @@ Step 8: Begin Interaction
 
 **Files in Context (in order):**
 1. `aliases.md` (always loaded)
-2. `.kiro/agents/kiro-master.md` (loaded by alias)
+2. `.kiro/kiro-agents/kiro-master.md` (loaded by alias)
 3. `agent-activation.md` (loaded by alias)
 4. `strict-mode.md` (loaded by activation protocol)
 5. `chit-chat.md` (loaded if agent uses it)
@@ -660,22 +660,22 @@ User installs: npx kiro-agents
 
 Step 1: Installation
 ├─ CLI installs steering files to ~/.kiro/steering/kiro-agents/
-├─ CLI installs kiro-protocols power to ~/.kiro/powers/kiro-protocols/
-├─ CLI creates symbolic links in ~/.kiro/powers/installed/kiro-protocols/
-├─ CLI registers power in ~/.kiro/powers/registry.json
+├─ CLI installs kiro-protocols source to ~/.kiro/powers/kiro-protocols/
+├─ CLI copies power files to ~/.kiro/powers/installed/kiro-protocols/
+├─ CLI registers power in installed.json + registries/user-added.json
 └─ Installation complete
 
 Step 2: First Command
 ├─ User opens Kiro IDE in a project
 ├─ User types: /agents
-└─ AI detects no agents exist in .kiro/agents/
+└─ AI detects no agents exist in .kiro/kiro-agents/
 
 Step 3: Auto-Setup
-├─ agents.md detects empty .kiro/agents/ directory
+├─ agents.md detects empty .kiro/kiro-agents/ directory
 ├─ AI automatically creates kiro-master agent:
 │   ├─ Name: kiro-master
 │   ├─ Description: "Interactive Kiro feature management..."
-│   └─ File: .kiro/agents/kiro-master.md
+│   └─ File: .kiro/kiro-agents/kiro-master.md
 └─ AI shows agent management menu with kiro-master listed
 
 Step 4: User Interaction
@@ -778,7 +778,7 @@ AI: [Shows customization options]
 User: 1 (Use as-is)
 
 AI: [Generates agent definition]
-    [Writes to .kiro/agents/technical-writer.md]
+    [Writes to .kiro/kiro-agents/technical-writer.md]
     [Shows summary]
     
     Agent created: technical-writer
@@ -1077,7 +1077,7 @@ Agents with Reflections section automatically load approved insights:
 
 ### Reflection Curator Agent
 
-**File:** `.kiro/agents/reflection-curator.md`
+**File:** `.kiro/kiro-agents/reflection-curator.md`
 
 **Responsibilities:**
 - Review draft insights from all agents
@@ -1203,80 +1203,56 @@ Where should this insight be approved to?
 
 ## Registry Integration
 
-### Registry File Location
+### Registry Files
 
-**Path:** `~/.kiro/powers/registry.json`
+The CLI writes to two files that Kiro IDE uses to track installed custom powers:
 
-**Purpose:** Track installed powers for Kiro IDE Powers UI
-
-### Registry Structure
+**`~/.kiro/powers/installed.json`** — installed powers manifest
 
 ```json
 {
   "version": "1.0.0",
-  "powers": {
-    "kiro-protocols": {
-      "name": "kiro-protocols",
-      "displayName": "Kiro Protocols",
-      "description": "Reusable protocol library for AI agents...",
-      "mcpServers": [],
-      "author": "R. Beltran",
-      "keywords": ["protocols", "workflows", "agents", "modes"],
-      "installed": true,
-      "installedAt": "2024-12-26T10:30:00.000Z",
-      "installPath": "~/.kiro/powers/installed/kiro-protocols",
-      "source": {
-        "type": "repo",
-        "repoId": "local-kiro-protocols",
-        "repoName": "~/.kiro/powers/kiro-protocols"
-      },
-      "sourcePath": "~/.kiro/powers/kiro-protocols"
-    }
-  },
-  "repoSources": {
-    "local-kiro-protocols": {
-      "name": "~/.kiro/powers/kiro-protocols",
-      "type": "local",
-      "enabled": true,
-      "addedAt": "2024-12-26T10:30:00.000Z",
-      "path": "~/.kiro/powers/kiro-protocols",
-      "lastSync": "2024-12-26T10:30:00.000Z",
-      "powerCount": 1
-    }
-  },
-  "lastUpdated": "2024-12-26T10:30:00.000Z"
+  "installedPowers": [
+    { "name": "kiro-protocols", "registryId": "user-added" }
+  ],
+  "dismissedAutoInstalls": []
 }
 ```
 
-### Registry Fields Explained
+**`~/.kiro/powers/registries/user-added.json`** — user-added powers registry
 
-**Power Entry:**
-- `installed: true` - Power is installed and ready to use
-- `installPath` - Points to symlink directory (for UI)
-- `sourcePath` - Points to actual power files
-- `source.type: "repo"` - Treated as repository source (not "local")
-- `source.repoId` - Stable identifier (no timestamp)
+```json
+{
+  "powers": [
+    {
+      "name": "kiro-protocols",
+      "description": "Custom power from ~/.kiro/powers/kiro-protocols",
+      "source": {
+        "type": "local",
+        "path": "~/.kiro/powers/kiro-protocols"
+      }
+    }
+  ]
+}
+```
 
-**Repo Source Entry:**
-- `type: "local"` - Local filesystem source
-- `path` - Full path to power directory
-- `powerCount: 1` - Number of powers in this source
+### How Kiro IDE Uses These Files
 
-### Why This Structure?
+On startup, Kiro IDE:
+1. Reads `installed.json` to determine which powers are installed
+2. For each installed power, looks up its `registryId` (`"user-added"`)
+3. Reads `registries/user-added.json` to find the power's `source.path`
+4. Reads the power files from `installed/kiro-protocols/` at runtime
 
-**Stable repoId:**
-- Uses `"local-kiro-protocols"` (no timestamp)
-- Prevents duplicate entries on reinstall
-- Matches Kiro's pattern for local powers
+The `source.path` in `user-added.json` is used as a reference to the origin of the power (equivalent to the local path a user provides in the "Add Custom Power" UI). Kiro IDE does not re-copy from this path on startup — the `installed/` directory is the runtime source of truth.
 
-**Two Paths:**
-- `installPath` - Where Kiro UI looks (symlinks)
-- `sourcePath` - Where actual files are (source of truth)
+### What the CLI Does NOT Modify
 
-**source.type: "repo":**
-- Ensures proper UI integration
-- Power appears as "installed" in Powers panel
-- Enables proper power management
+**`~/.kiro/powers/registry.json`** — this is the marketplace catalog managed exclusively by Kiro IDE. The CLI does not touch it.
+
+### Merge Behavior
+
+Both registry files are merged with existing content during installation. Other installed powers are preserved.
 
 ---
 
@@ -1284,20 +1260,22 @@ Where should this insight be approved to?
 
 ### After Installation
 
-**All installed files are read-only:**
-
-```bash
-# Steering files
+**Steering files — read-only:**
+```
 ~/.kiro/steering/kiro-agents/*.md  # r--r--r-- (444)
-
-# Power files
-~/.kiro/powers/kiro-protocols/**/*  # r--r--r-- (444)
 ```
 
-**Why read-only?**
-- Prevents accidental modification
-- Ensures consistency across installations
-- Users can't break system by editing files
+**Power source — writable:**
+```
+~/.kiro/powers/kiro-protocols/**/*  # rw-r--r-- (644)
+```
+Kept writable so Kiro IDE can read it as a source directory without permission errors.
+
+**Power installed — read-only:**
+```
+~/.kiro/powers/installed/kiro-protocols/**/*  # r--r--r-- (444)
+```
+Matches what Kiro IDE sets when it installs a power via UI.
 
 ### Modifying Files
 
@@ -1361,7 +1339,7 @@ Error loading protocol: agent-creation.md not found
 
 **Symptom:**
 ```
-Agent 'my-agent' not found in .kiro/agents/
+Agent 'my-agent' not found in .kiro/kiro-agents/
 ```
 
 **Causes:**
@@ -1372,12 +1350,12 @@ Agent 'my-agent' not found in .kiro/agents/
 **Solutions:**
 1. **Check agent directory:**
    ```bash
-   ls .kiro/agents/
+   ls .kiro/kiro-agents/
    ```
 
 2. **Verify workspace:**
    - Ensure you're in correct project directory
-   - Check if `.kiro/agents/` exists
+   - Check if `.kiro/kiro-agents/` exists
 
 3. **Create agent:**
    ```
@@ -1457,18 +1435,19 @@ Power not showing as installed in Kiro Powers UI
    ```bash
    npx kiro-agents
    ```
-   - Automatically updates registry
-   - Recreates symbolic links
+   - Automatically updates registry files
+   - Recreates installed/ copy
 
-2. **Check registry file:**
+2. **Check registry files:**
    ```bash
-   cat ~/.kiro/powers/registry.json
+   cat ~/.kiro/powers/installed.json
+   cat ~/.kiro/powers/registries/user-added.json
    ```
-   - Look for "kiro-protocols" entry
-   - Verify `installed: true`
+   - Look for "kiro-protocols" entry in installedPowers
+   - Verify source.path points to ~/.kiro/powers/kiro-protocols
 
-3. **Manual registry fix (advanced):**
-   - Delete registry.json
+3. **Manual fix (advanced):**
+   - Delete ~/.kiro/powers/installed/kiro-protocols/
    - Reinstall kiro-agents
    - Registry recreated automatically
 

--- a/docs/contributing/DUAL_INSTALLATION.md
+++ b/docs/contributing/DUAL_INSTALLATION.md
@@ -4,17 +4,23 @@ kiro-agents uses a dual-distribution architecture that installs both steering fi
 
 ## Installation Targets
 
-**Steering files** → `~/.kiro/steering/kiro-agents/`
+**Steering files** → `~/.kiro/steering/kiro-agents/` (read-only)
 - Core system files providing foundational kiro-agents functionality
 - Instruction aliases, agent management, mode switching, strict mode control
 - Interactive interfaces (agents.md, modes.md, strict.md, reflect.md)
 - Interaction patterns and mode definitions
 
-**Power dependency** → `~/.kiro/powers/kiro-protocols/`
+**Power source** → `~/.kiro/powers/kiro-protocols/` (writable)
 - POWER.md (power metadata)
 - mcp.json (empty MCP config)
 - icon.png (power icon)
 - steering/ (reusable protocols)
+- Kept writable so Kiro IDE can read it as a source directory
+
+**Power installed** → `~/.kiro/powers/installed/kiro-protocols/` (read-only)
+- Physical copy of power files (no symlinks)
+- Where Kiro IDE reads the power from at runtime
+- Does not include icon.png (Kiro IDE skips it during install)
 
 ## Why This Architecture?
 
@@ -25,6 +31,10 @@ The kiro-protocols power contains reusable protocol files referenced by steering
 - Independent updates
 - Reusability across projects
 - Automatic registration in Kiro's power system
+
+The two-directory approach (`kiro-protocols/` + `installed/kiro-protocols/`) mirrors exactly what Kiro IDE does when a user installs a power via "Add Custom Power" UI:
+- `kiro-protocols/` acts as the registered source (equivalent to the local path the user provides in the UI)
+- `installed/kiro-protocols/` is the physical copy Kiro IDE creates and reads from at runtime
 
 ## Build Process
 
@@ -55,64 +65,64 @@ bun run build
 When user runs `npx kiro-agents`:
 
 1. **Remove old installations** (if present)
-2. **Install steering files** to `~/.kiro/steering/kiro-agents/`
-3. **Install power files** to `~/.kiro/powers/kiro-protocols/`
-4. **Create symbolic links** in `~/.kiro/powers/installed/kiro-protocols/`
-5. **Register power** in `~/.kiro/powers/registry.json`
+2. **Install steering files** to `~/.kiro/steering/kiro-agents/` (read-only)
+3. **Install power source files** to `~/.kiro/powers/kiro-protocols/` (writable)
+4. **Copy power files** to `~/.kiro/powers/installed/kiro-protocols/` (read-only physical copy)
+5. **Register power** in `~/.kiro/powers/installed.json` and `~/.kiro/powers/registries/user-added.json`
 6. **Show success message**
 
 ## Automatic Power Registration
 
-The CLI automatically registers kiro-protocols in Kiro's registry following the exact pattern used by Kiro IDE:
+The CLI registers kiro-protocols by writing to the two files Kiro IDE uses to track installed custom powers:
 
+**`~/.kiro/powers/installed.json`**
 ```json
 {
-  "powers": {
-    "kiro-protocols": {
-      "installed": true,
-      "installedAt": "2025-12-16T...",
-      "installPath": "~/.kiro/powers/installed/kiro-protocols",
-      "source": {
-        "type": "repo",
-        "repoId": "local-kiro-protocols",
-        "repoName": "~/.kiro/powers/kiro-protocols"
-      },
-      "sourcePath": "~/.kiro/powers/kiro-protocols"
-    }
-  },
-  "repoSources": {
-    "local-kiro-protocols": {
-      "name": "~/.kiro/powers/kiro-protocols",
-      "type": "local",
-      "enabled": true,
-      "path": "~/.kiro/powers/kiro-protocols",
-      "powerCount": 1
-    }
-  }
+  "version": "1.0.0",
+  "installedPowers": [
+    { "name": "kiro-protocols", "registryId": "user-added" }
+  ],
+  "dismissedAutoInstalls": []
 }
 ```
 
-**Key features:**
-- Uses stable repo ID `"local-kiro-protocols"` (no timestamp conflicts)
-- `installPath` points to `installed/` directory with symlinks
-- `sourcePath` points to actual power directory
-- Power appears immediately as "installed" in Kiro Powers UI
+**`~/.kiro/powers/registries/user-added.json`**
+```json
+{
+  "powers": [
+    {
+      "name": "kiro-protocols",
+      "description": "Custom power from ~/.kiro/powers/kiro-protocols",
+      "source": {
+        "type": "local",
+        "path": "~/.kiro/powers/kiro-protocols"
+      }
+    }
+  ]
+}
+```
+
+**Key points:**
+- Both files are merged with existing content (other installed powers are preserved)
+- `registry.json` is NOT modified — that file is the marketplace catalog managed by Kiro IDE
+- The `source.path` points to `kiro-protocols/` (writable source), not `installed/kiro-protocols/`
 
 ### Implementation Details
 
-**Symbolic Links** (`createSymbolicLinks()`)
-- Creates `installed/kiro-protocols/` directory
-- Links each file and directory from power
-- Platform-specific: Windows uses junction for directories, symlink for files
+**Physical file copy** (`installPowerFiles()`)
+- Removes existing `installed/kiro-protocols/` for clean install
+- Copies all files from `kiro-protocols/` to `installed/kiro-protocols/`
+- Excludes `icon.png` (Kiro IDE does not copy it)
+- Sets all copied files to read-only
 
-**Registry Registration** (`registerPowerInRegistry()`)
-- Extracts metadata from POWER.md frontmatter
-- Creates/updates registry entries
-- Graceful error handling (non-blocking)
+**Registry registration** (`registerPower()`)
+- Reads and merges `installed.json` and `registries/user-added.json`
+- Extracts power name/description from POWER.md frontmatter
+- Graceful error handling (non-blocking — warns but continues)
 
 **Error Handling:**
-- Registry registration errors logged as warnings
-- Installation continues even if registration fails
+- Copy/registration errors logged as warnings
+- Installation continues even if these steps fail
 - User gets manual activation instructions as fallback
 
 ## Testing
@@ -129,9 +139,11 @@ kiro-agents
 # Verify installations
 ls ~/.kiro/steering/kiro-agents/
 ls ~/.kiro/powers/kiro-protocols/
+ls ~/.kiro/powers/installed/kiro-protocols/
 
 # Verify registry
-cat ~/.kiro/powers/registry.json | grep -A 10 "kiro-protocols"
+cat ~/.kiro/powers/installed.json
+cat ~/.kiro/powers/registries/user-added.json
 
 # Check Kiro Powers UI
 # Should see "kiro-protocols" with "Installed" badge

--- a/docs/contributing/TESTING.md
+++ b/docs/contributing/TESTING.md
@@ -45,7 +45,8 @@ ls ~/.kiro/steering/kiro-agents/
 ls ~/.kiro/powers/kiro-protocols/
 
 # Check registry
-cat ~/.kiro/powers/registry.json | grep "kiro-protocols"
+cat ~/.kiro/powers/installed.json
+cat ~/.kiro/powers/registries/user-added.json
 ```
 
 ### Testing Power in Kiro IDE
@@ -122,5 +123,5 @@ Test on:
 Verify:
 - File permissions set correctly
 - Paths resolve properly
-- Symbolic links created
-- Registry registration works
+- Physical file copy to installed/ works
+- Registry registration works (installed.json + user-added.json)

--- a/docs/design/reflection-architecture.md
+++ b/docs/design/reflection-architecture.md
@@ -170,7 +170,7 @@ This agent records insights, patterns, and learnings in its dedicated reflection
 
 ### 5. Curator Agent
 
-**File:** `.kiro/agents/reflection-curator.md`
+**File:** `.kiro/kiro-agents/reflection-curator.md`
 
 **Responsibilities:**
 - Review draft insights

--- a/docs/user-guide/reflection-system.md
+++ b/docs/user-guide/reflection-system.md
@@ -518,7 +518,7 @@ Create custom agent categories in agent definitions to organize category-tier in
 
 ## Learn More
 
-- **Curator Agent:** `.kiro/agents/reflection-curator.md` - Full agent definition
+- **Curator Agent:** `.kiro/kiro-agents/reflection-curator.md` - Full agent definition
 - **Protocols:** `~/.kiro/powers/kiro-protocols/steering/reflect-*.md` - Detailed workflows
 - **Proposal:** `proposals/ai-managed-storage-and-reflection-system-v2.md` - Design rationale
 

--- a/scripts/finalize.ts
+++ b/scripts/finalize.ts
@@ -528,7 +528,7 @@ async function analyzePhase() {
  * files, attempted features that were reverted).
  * 
  * **How It Works:**
- * 1. Extracts all path-like patterns from changeset (e.g., `docs/__internal/`, `.kiro/agents/`)
+ * 1. Extracts all path-like patterns from changeset (e.g., `docs/__internal/`, `.kiro/kiro-agents/`)
  * 2. Gets actual changed files from git diff
  * 3. Cross-references each path against actual files
  * 4. Reports any paths that don't exist in the commit
@@ -558,7 +558,7 @@ function validateChangesetAgainstDiff(changesetFile: string): { valid: boolean; 
   const errors: string[] = [];
 
   // Extract all file/directory references from changeset
-  // Look for common patterns: `path/to/file`, docs/__internal/, .kiro/agents/, etc.
+  // Look for common patterns: `path/to/file`, docs/__internal/, .kiro/kiro-agents/, etc.
   const pathPattern = /`([^`]+\/[^`]+)`|([a-zA-Z0-9_-]+\/[a-zA-Z0-9_\/-]+)/g;
   const matches = content.matchAll(pathPattern);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,6 +124,8 @@ export const substitutions = {
   '{{{KIRO_MODE_ALIASES}}}': () => '',
   /** Workspace agents directory path (e.g., '.ai-agents/agents' for cross-IDE compatibility) */
   '{{{WS_AGENTS_PATH}}}': () => '.ai-agents/agents',
+  /** Global (user-level) agents directory path */
+  '{{{GLOBAL_AGENTS_PATH}}}': () => '~/.ai-agents/agents',
   /** Initial agent name created during auto-setup (e.g., 'project-master') */
   '{{{INITIAL_AGENT_NAME}}}': () => 'project-master',
   /** 

--- a/src/core/protocols/strict-mode.md
+++ b/src/core/protocols/strict-mode.md
@@ -142,7 +142,7 @@ ACTIVE_AGENT: none | {agent-name}
 
 **Agent activation:**
 - Triggered by `/agents {agent-name}` command
-- Loads `.kiro/agents/{agent-name}.md` into context
+- Loads `{{{WS_AGENTS_PATH}}}/{agent-name}.md` into context
 - Executes agent-activation protocol
 - Sets ACTIVE_AGENT = {agent-name}
 

--- a/src/kiro/config.ts
+++ b/src/kiro/config.ts
@@ -38,13 +38,17 @@ function getVersion(): string {
 }
 
 /**
- * Scans `.kiro/agents/` for agent definitions (fallback message if directory missing).
+ * Scans `.kiro/kiro-agents/` for agent definitions (fallback message if directory missing).
  * 
- * @returns Markdown bullet list of agent names without .md extension
+ * Reads workspace-level agent `.md` files from `.kiro/kiro-agents/` and formats them
+ * as a markdown bullet list for injection into steering documents via `{{{AGENT_LIST}}}`.
+ * 
+ * @returns Markdown bullet list of agent names (without `.md` extension), or default
+ *   fallback `"- kiro-master (auto-created on first use)"` if directory is absent or empty
  */
 function getAgentList(): string {
   try {
-    const agentsDir = ".kiro/agents";
+    const agentsDir = ".kiro/kiro-agents";
     const files = readdirSync(agentsDir);
     const agents = files
       .filter(f => f.endsWith(".md"))
@@ -121,7 +125,7 @@ const getSteeringsPath = (target: string) => {
  * **Agent system overrides:**
  * - Can override `WS_AGENTS_PATH`, `INITIAL_AGENT_NAME`, `INITIAL_AGENT_DESCRIPTION` if Kiro needs different values
  * - Base config provides cross-IDE defaults (`.ai-agents/agents`, `project-master`)
- * - Kiro typically uses `.kiro/agents/` and `kiro-master` instead
+ * - Kiro typically uses `.kiro/kiro-agents/` and `kiro-master` instead
  * 
  * @see src/config.ts - Base substitutions with all required keys
  * @see scripts/build.ts - Multi-pass substitution processor
@@ -145,7 +149,9 @@ export const substitutions = {
   '{{{PROTOCOLS_PATH}}}': ({ target }: any) => getSteeringsPath(target) + '/protocols',
   '{{{KIRO_PROTOCOLS_PATH}}}': ({ target }: any) => getSteeringsPath(target) + '/protocols',
   /** Override workspace agents path for Kiro */
-  '{{{WS_AGENTS_PATH}}}': () => '.kiro/agents',
+  '{{{WS_AGENTS_PATH}}}': () => '.kiro/kiro-agents',
+  /** Global (user-level) agents path for Kiro */
+  '{{{GLOBAL_AGENTS_PATH}}}': () => '~/.kiro/kiro-agents',
   /** Override initial agent name for Kiro */
   '{{{INITIAL_AGENT_NAME}}}': () => 'kiro-master',
   /** Override initial agent description for Kiro */

--- a/src/kiro/docs/QUICK-REFERENCE.md
+++ b/src/kiro/docs/QUICK-REFERENCE.md
@@ -133,7 +133,7 @@ inclusion: manual
 
 ## Available Agents
 
-Check `.kiro/agents/` directory or use `/agents` command
+Check `.kiro/kiro-agents/` directory or use `/agents` command
 
 ## Tips
 

--- a/src/kiro/docs/kiro-docs/subagents.md
+++ b/src/kiro/docs/kiro-docs/subagents.md
@@ -1,0 +1,105 @@
+# Subagents
+
+Subagents allow Kiro to run multiple tasks in parallel, or delegate specific tasks to subagents that specialize in those tasks. Kiro will automatically launch subagents as appropriate. You can also launch subagents manually by instructing Kiro to do so via a prompt such as "Run subagents to...".
+
+ 
+
+Kiro has two built-in subagents: a "context gathering" subagent used to explore a project and gather relevant context, and a "general purpose" subagent used for parallelizing all other tasks.
+
+ 
+
+Subagents run in parallel; however, the main Kiro agent will wait until all subagents have completed before proceeding. Each subagent has its own context window, ensuring that the main agent context is not polluted by the subagent's execution. Subagents automatically return their results back to the main agent once they finish.
+
+ 
+
+[Steering files](https://kiro.dev/docs/steering/) and [MCP servers](https://kiro.dev/docs/mcp/) work in subagents exactly as they do in the main agent. However, subagents do not have access to [Specs](https://kiro.dev/docs/specs/), and [Hooks](https://kiro.dev/docs/hooks/) will not trigger in subagents.
+
+ 
+
+You can significantly speed up development by leveraging subagents to perform multiple tasks simultaneously. In the following example, subagents are used to fetch and analyze several tickets in parallel. Not only is this faster than analyzing the tickets sequentially, the tool call and ticket details stay within each subagent and do not pollute the main agent's context.
+
+## Custom subagents
+
+ 
+
+You can define your own custom agent by creating a markdown (.md) file in `~/.kiro/agents` (global) or `<workspace>/.kiro/agents` (workspace scope). Enter the prompt for the custom agent in the body of the markdown file, and define additional attributes as YAML front matter.
+
+ 
+
+For example, to create a simple "code reviewer" custom agent, create `~/.kiro/agents/code-reviewer.md` with the following content:
+
+```
+
+---
+
+name: code-reviewer
+
+description: Expert code review assistant.
+
+tools: ["read", "@context7"]
+
+model: claude-sonnet-4
+
+---
+
+You are a senior code reviewer.
+
+## Your Responsibilities
+
+- Review code for correctness, performance, and security
+
+...
+
+```
+
+### Invocation
+
+ 
+
+When launching subagents, Kiro will automatically select the appropriate custom agent configuration for each subagent, based on the `description` field. You can also explicitly ask Kiro to use a specific subagent, for example, "Use the code-reviewer subagent to find performance issues in my code". Subagents also appear as slash commands, so you can also use "/code-reviewer find performance issues in my code".
+
+ 
+
+### Attributes
+
+ 
+
+Below is a list of attributes you can use in the frontmatter. The **name** attribute is mandatory; all others are optional.
+
+| Attribute      | Description                                        | Example value                | Default value, if omitted      |
+
+|----------------|----------------------------------------------------|------------------------------|--------------------------------|
+
+| name           | Name of the agent                                  | code-reviewer                | Name of the .md file           |
+
+| description    | Description of the agent                           | Expert code review assistant | No description                 |
+
+| tools          | List (array) of tools the agent can access         | ["@builtin", "@context7"]    | No tools                       |
+
+| model          | The model to use                                   | claude-sonnet-4              | LLM currently selected in chat |
+
+| includeMcpJson | If true, then all MCP tools are included           | true                         | false                          |
+
+| includePowers  | If true, then all MCP tools in Powers are included | true                         | false                          |
+
+In the **tools** field, you can use the following:
+
+ 
+
+- **read**: all built-in file read tools
+
+- **write**: all built-in file write tools
+
+- **shell**: all built-in shell command-related tools
+
+- **web**: all built-in web tools
+
+- **spec**: all built-in spec-related tools (only valid in Spec mode)
+
+- **@builtin**: all built-in tools
+
+- **@<mcp_server>**: all tools from a specific MCP server, e.g., **@figma**
+
+- **@<mcp_server>/<tool>**: a specific tool from a specific MCP server, e.g., **@figma/get_figjam**
+
+Wildcarding is supported, e.g., `tools: ["*"]` to include all built-in and MCP tools, or `tools: ["@figma/*"]` to include all tools from the **figma** MCP server.


### PR DESCRIPTION
# Migrate agent definitions directory to avoid conflict with Kiro Subagents

Kiro IDE's official Subagents feature uses the same directory as kiro-agents for custom agent definitions, causing Kiro models to fail when listing or reading Subagents due to incompatible file formats. The agent storage path has been updated across the build system, protocols, and all documentation to resolve this conflict.

## Added
- New `{{{GLOBAL_AGENTS_PATH}}}` substitution key in `src/config.ts` and `src/kiro/config.ts` for global user-level agent path

## Changed
- `src/kiro/config.ts`: updated `{{{WS_AGENTS_PATH}}}` substitution and `getAgentList()` to use new agent directory
- `src/core/protocols/strict-mode.md`: replaced hardcoded agent path with `{{{WS_AGENTS_PATH}}}` substitution
- Documentation updated across `README.md`, `CONTRIBUTING.md`, `docs/ARCHITECTURE.md`, `docs/GETTING_STARTED.md`, `docs/INSTALLED-ARCHITECTURE.md`, `docs/design/reflection-architecture.md`, `docs/user-guide/reflection-system.md`

## Fixed
- Conflict with Kiro IDE's official Subagents feature that caused model failures when scanning for custom subagents